### PR TITLE
Close incidents tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,36 @@ optional arguments:
 See: https://github.com/Preocts/pagerduty-utils
 ```
 
+Example use: Polling for incidents older than 5 days without priority or activity
+
+Command: `close-old-incidents --token [API_TOKEN] --email [EMAIL] --close-after-days 5`
+
+```shell
+(venv) preocts @ Preocts ~/pd-utils (preocts-close-incidents)
+└─▶ $ close-old-incidents --token [API_TOKEN] --email [EMAIL] --close-after-days 5
+2022-08-02 22:14:25,261 - INFO - close_old_incidents - Pulling incidents from PagerDuty, this can take a while
+2022-08-02 22:14:25,759 - INFO - close_old_incidents - Discovered 2 incidents.
+2022-08-02 22:14:25,759 - INFO - close_old_incidents - Found 2 open incidents
+2022-08-02 22:14:25,759 - INFO - close_old_incidents - Isolated 2 old incidents
+2022-08-02 22:14:25,759 - INFO - close_old_incidents - Isolated 1 nonpriority incidents
+2022-08-02 22:14:25,759 - INFO - close_old_incidents - Checking incident 0 to 100
+2022-08-02 22:14:25,914 - INFO - close_old_incidents - Isolated 1 inactive incidents
+2022-08-02 22:14:25,915 - INFO - close_old_incidents - Wrote 1 rows to close-old-incidents-preview-20220802-2214.csv
+```
+
+Example use: Closing incidents found in above step
+
+Command `close-old-incidents --token [API_TOKEN] --email [EMAIL] --inputfile close-old-incidents-preview-20220802-2214.csv`
+
+```shell
+(venv) preocts @ Preocts ~/pd-utils (preocts-close-incidents)
+└─▶ $ close-old-incidents --token [API_TOKEN] --email [EMAIL] --inputfile close-old-incidents-preview-20220802-2214.csv
+2022-08-02 22:18:10,383 - INFO - close_old_incidents - Reading input file: close-old-incidents-preview-20220802-2214.csv
+2022-08-02 22:18:10,383 - INFO - close_old_incidents - Read 1 inactives, starting actions
+2022-08-02 22:18:10,384 - INFO - close_old_incidents - Start close actions on 1 incidents.
+2022-08-02 22:18:11,247 - INFO - close_old_incidents - Wrote 1 rows to close-old-incidents-20220802-2218.csv
+```
+
 ---
 
 ## Safelist Gatherer

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [Command line scripts:](#command-line-scripts)
 - [Available scripts](#available-scripts)
   - [Coverage Gap Report](#coverage-gap-report)
+  - [Close Old Incidents](#close-old-incidents)
   - [Safelist Gatherer](#safelist-gatherer)
   - [Simple Alert](#simple-alert)
 - [Local developer installation](#local-developer-installation)
@@ -121,6 +122,48 @@ P46S1RA,Mind the gap,https://preocts.pagerduty.com/escalation_policies/P46S1RA,1
 P46S1RA,Mind the gap,https://preocts.pagerduty.com/escalation_policies/P46S1RA,2,"('Morning shift', 'Late shift no gap')","('PQ1AJP1', 'PRZTRI8')",False,True
 P46S1RA,Mind the gap,https://preocts.pagerduty.com/escalation_policies/P46S1RA,3,"('Preocts Full Coverage',)","('P4TPEME',)",False,True
 P46S1RA,Mind the gap,https://preocts.pagerduty.com/escalation_policies/P46S1RA,4,"('Preocts Coverage Gaps',)","('PG3MDI8',)",False,False
+```
+
+---
+
+## Close Old Incidents
+
+A tool created to enforce the maximum age of incidents on a large scale
+implementation of PagerDuty. Runs in two steps:
+
+1. First run scans PagerDuty for incidents that match the critiria for
+   auto-closing
+2. Second run requires inputfile generated from first run and closes incidents
+
+Default Critiria:
+
+- Any incident *older* than 10 days
+- AND, does not have any activy in logs within last 10 days
+- AND, does not have a Priority assigned
+
+**Note: This scripts requires read/write to PagerDuty and performs an action
+that cannot be reversed. Once an incident is closed it cannot be reopened.**
+
+```shell
+usage: close-old-incidents [-h] [--token TOKEN] [--email EMAIL] [--logging-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] [--inputfile INPUTFILE] [--close-after-days CLOSE_AFTER_DAYS]
+                           [--close-active] [--close-priority]
+
+Pagerduty command line utilities.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --token TOKEN         PagerDuty API Token (default: $PAGERDUTY_TOKEN)
+  --email EMAIL         PagerDuty Email (default: $PAGERDUTY_EMAIL)
+  --logging-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+                        Logging level (default: $LOGGING_LEVEL | INFO)
+  --inputfile INPUTFILE
+                        Provide a csv file to work from. If not provided a new file will be created.
+  --close-after-days CLOSE_AFTER_DAYS
+                        Incidents older than this are considered for closing (default: 10)
+  --close-active        When present, old incidents are closed regardless of activity
+  --close-priority      When present, consider incidents with priority for closing
+
+See: https://github.com/Preocts/pagerduty-utils
 ```
 
 ---

--- a/pd_utils/close_old_incidents.py
+++ b/pd_utils/close_old_incidents.py
@@ -106,7 +106,7 @@ class CloseOldIncidents:
         return [Incident.build_from(incident) for incident in incidents]
 
     # TODO: preocts - Reused code - This needs to be extracted into a helper
-    def _get_newest_log_entry(self, incident_id: str) -> list[dict[str, Any]]:
+    def _get_newest_log_entry(self, incident_id: str) -> dict[str, Any]:
         """Pull most recent log entry from incident."""
 
         params: dict[str, Any] = {
@@ -125,7 +125,7 @@ class CloseOldIncidents:
             self.log.error("Unexpected error: %s", resp.text)
             raise QueryError("Unexpected error")
 
-        return resp.json()["log_entries"]
+        return resp.json()["log_entries"][0]
 
 
 if __name__ == "__main__":

--- a/pd_utils/close_old_incidents.py
+++ b/pd_utils/close_old_incidents.py
@@ -1,0 +1,142 @@
+"""Clean up stale or ignored incidents in PagerDuty."""
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import Any
+from typing import Dict
+from typing import TypedDict
+
+import httpx
+
+from pd_utils.util import RuntimeInit
+
+# import csv
+# from pd_utils.util import DateTool
+
+
+EXPIRE_DAYS = 10  # Number of days a incident can be open before it is closed
+FILEDATE = datetime.datetime.now().strftime("%Y-%m-%dT%H.%M.%SZ")
+NOW = datetime.datetime.now()
+
+Incident = Dict[str, Any]
+
+runtime = RuntimeInit("close-old-incidents")
+runtime.init_secrets()
+runtime.init_logging()
+
+
+class IncidentRow(TypedDict):
+    incident_url: str
+    incident_id: str
+    incident_number: str
+    urgency: str
+    severity: str
+    opened_at: str
+    last_status_update_at: str
+    age_in_days: int
+
+
+class QueryError(Exception):
+    ...
+
+
+class CloseOldIncidents:
+    """Use to clean up and close old incidents in PagerDuty."""
+
+    log = logging.getLogger(__name__)
+    base_url = "https://api.pagerduty.com"
+
+    def __init__(
+        self,
+        token: str,
+        email: str,
+        *,
+        close_after_days: int = 10,
+        close_active: bool = False,
+        close_priority: bool = False,
+    ) -> None:
+        """
+        Used to clean up and close old incidents in PagerDuty.
+
+        Args:
+            token: API v2 read/write token for PagerDuty
+            email: Valid PagerDuty account email with permissions for closing incidents
+            close_after_days: Incidents older than this are considered for closing
+            close_after: When true, old incidents are closed regardless of activity
+            close_priority: When true, consider incidents with priority for closing
+        """
+
+        headers = {
+            "Accept": "application/vnd.pagerduty+json;version=2",
+            "Authorization": f"Token token={token}",
+            "From": email,
+        }
+
+        self._http = httpx.Client(headers=headers)
+        self._max_query_limit = 1
+        self._incidents: list[IncidentRow] = []
+        self._errors: list[IncidentRow] = []
+
+    # TODO: preocts - Reused code - This needs to be extracted into a helper
+    def _get_all_incidents(self) -> list[dict[str, Any]]:
+        """Pull all open incidents from PagerDuty."""
+        more = True
+        params: dict[str, Any] = {
+            "time_zone": "UTC",
+            "statuses[]": ["triggered", "acknowledged"],
+            "offset": 0,
+            "limit": self._max_query_limit,
+        }
+        incidents: list[dict[str, Any]] = []
+
+        while more:
+            self.log.debug("List incidents: %s", params)
+            resp = self._http.get(f"{self.base_url}/incidents", params=params)
+
+            if not resp.is_success:
+                self.log.error("Unexpected error: %s", resp.text)
+                raise QueryError("Unexpected error")
+
+            incidents.extend(resp.json()["incidents"])
+
+            params["offset"] += self._max_query_limit
+            more = resp.json()["more"]
+
+        self.log.info("Discovered %d incidents.", len(incidents))
+
+        return incidents
+
+    # TODO: preocts - Reused code - This needs to be extracted into a helper
+    def _get_newest_log_entry(self, incident_id: str) -> list[dict[str, Any]]:
+        """Pull most recent log entry from incident."""
+
+        params: dict[str, Any] = {
+            "time_zone": "UTC",
+            "offset": 0,
+            "limit": 1,
+        }
+
+        self.log.debug("List log entry: %s", params)
+        resp = self._http.get(
+            url=f"{self.base_url}/incidents/{incident_id}/log_entries",
+            params=params,
+        )
+
+        if not resp.is_success:
+            self.log.error("Unexpected error: %s", resp.text)
+            raise QueryError("Unexpected error")
+
+        return resp.json()["log_entries"]
+
+
+if __name__ == "__main__":
+    client = CloseOldIncidents(
+        token=runtime.secrets.get("PAGERDUTY_TOKEN"),
+        email=runtime.secrets.get("PAGERDUTY_EMAIL"),
+    )
+    resp = client._get_all_incidents()
+    for incident in resp:
+        client._get_newest_log_entry(incident["id"])
+
+    raise SystemExit()

--- a/pd_utils/close_old_incidents.py
+++ b/pd_utils/close_old_incidents.py
@@ -100,6 +100,25 @@ class CloseOldIncidents:
 
         return nonpriority_incidents
 
+    def _isolate_inactive_incidents(self, incidents: list[Incident]) -> list[Incident]:
+        """Isolate inactive incidents from list of incidents."""
+        inactive_incidents: list[Incident] = []
+
+        for idx, incident in enumerate(incidents):
+            if idx % 100 == 0:
+                self.log.info("Checking incident %s to %s", idx, idx + 100)
+
+            lst_log = self._get_newest_log_entry(incident.incident_id)
+            seconds = DateTool.to_seconds(NOW.isoformat(), lst_log["created_at"])
+            print(seconds)
+
+            if seconds > self._close_after_seconds:
+                self.log.debug("Incident %s has no activity", incident.incident_number)
+                inactive_incidents.append(incident)
+        self.log.info("Isolated %s inactive incidents", len(inactive_incidents))
+
+        return inactive_incidents
+
     # TODO: preocts - Reused code - This needs to be extracted into a helper
     def _get_all_incidents(self) -> list[Incident]:
         """Pull all open incidents from PagerDuty."""

--- a/pd_utils/close_old_incidents.py
+++ b/pd_utils/close_old_incidents.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 import datetime
 import logging
 from typing import Any
-from typing import Dict
 from typing import TypedDict
 
 import httpx
 
+from pd_utils.model import Incident
 from pd_utils.util import RuntimeInit
 
 # import csv
@@ -18,8 +18,6 @@ from pd_utils.util import RuntimeInit
 EXPIRE_DAYS = 10  # Number of days a incident can be open before it is closed
 FILEDATE = datetime.datetime.now().strftime("%Y-%m-%dT%H.%M.%SZ")
 NOW = datetime.datetime.now()
-
-Incident = Dict[str, Any]
 
 runtime = RuntimeInit("close-old-incidents")
 runtime.init_secrets()
@@ -79,7 +77,7 @@ class CloseOldIncidents:
         self._errors: list[IncidentRow] = []
 
     # TODO: preocts - Reused code - This needs to be extracted into a helper
-    def _get_all_incidents(self) -> list[dict[str, Any]]:
+    def _get_all_incidents(self) -> list[Incident]:
         """Pull all open incidents from PagerDuty."""
         more = True
         params: dict[str, Any] = {
@@ -105,7 +103,7 @@ class CloseOldIncidents:
 
         self.log.info("Discovered %d incidents.", len(incidents))
 
-        return incidents
+        return [Incident.build_from(incident) for incident in incidents]
 
     # TODO: preocts - Reused code - This needs to be extracted into a helper
     def _get_newest_log_entry(self, incident_id: str) -> list[dict[str, Any]]:
@@ -137,6 +135,6 @@ if __name__ == "__main__":
     )
     resp = client._get_all_incidents()
     for incident in resp:
-        client._get_newest_log_entry(incident["id"])
+        client._get_newest_log_entry(incident.incident_id)
 
     raise SystemExit()

--- a/pd_utils/close_old_incidents.py
+++ b/pd_utils/close_old_incidents.py
@@ -77,7 +77,7 @@ class CloseOldIncidents:
         self._close_priority = close_priority
 
     def _isolate_old_incidents(self, incidents: list[Incident]) -> list[Incident]:
-        """Isolate old incidents from internal list of incidents."""
+        """Isolate old incidents from list of incidents."""
         old_incidents: list[Incident] = []
         for incident in incidents:
             delta = DateTool.to_seconds(NOW.isoformat(), incident.created_at)
@@ -86,6 +86,19 @@ class CloseOldIncidents:
         self.log.info("Isolated %s old incidents", len(old_incidents))
 
         return old_incidents
+
+    def _isolate_nonpriority_incidents(
+        self,
+        incidents: list[Incident],
+    ) -> list[Incident]:
+        """Isolate nonpriority incidents from list of incidents."""
+        nonpriority_incidents: list[Incident] = []
+        for incident in incidents:
+            if not incident.has_priority:
+                nonpriority_incidents.append(incident)
+        self.log.info("Isolated %s nonpriority incidents", len(nonpriority_incidents))
+
+        return nonpriority_incidents
 
     # TODO: preocts - Reused code - This needs to be extracted into a helper
     def _get_all_incidents(self) -> list[Incident]:

--- a/pd_utils/close_old_incidents.py
+++ b/pd_utils/close_old_incidents.py
@@ -225,7 +225,7 @@ def main(args_in: list[str] | None = None) -> int:
     runtime.add_argument(
         flag="--close-after-days",
         default="10",
-        help_="Incidents older than this are considered for closing",
+        help_="Incidents older than this are considered for closing (default: 10)",
     )
     runtime.parser.add_argument(
         "--close-active",

--- a/pd_utils/close_old_incidents.py
+++ b/pd_utils/close_old_incidents.py
@@ -77,23 +77,24 @@ class CloseOldIncidents:
             to_close = self._load_input_file(inputfile)
             self.log.info("Read %s inactives, starting actions", len(to_close))
 
-            # self._close_incidents(to_close)
+            successes, errors = self._close_incidents(to_close)
 
-            # self._write_file("close-old-incidents", self._incidents)
-            # self._write_file("close-old-incidents-errors", self._errors)
+            self._write_file(successes, "close-old-incidents")
+            self._write_file(errors, "close-old-incidents-errors")
 
         else:
             self.log.info("Pulling incidents from PagerDuty, this can take a while")
             all_incidents = self._get_all_incidents()
             self.log.info("Found %s open incidents", len(all_incidents))
 
-            isolated_incidents = self._isolate_old_incidents(all_incidents)
-            isolated_incidents = self._isolate_nonpriority_incidents(isolated_incidents)
+            isolated = self._isolate_old_incidents(all_incidents)
+            isolated = self._isolate_nonpriority_incidents(isolated)
 
             # Inactive scanning requires additional calls to PD, run last
-            isolated_incidents = self._isolate_inactive_incidents(isolated_incidents)
+            if not self._close_active:
+                isolated = self._isolate_inactive_incidents(isolated)
 
-            self._write_file(isolated_incidents, "close-old-incidents-preview")
+            self._write_file(isolated, "close-old-incidents-preview")
 
     def _load_input_file(self, inputfile: str) -> list[Incident]:
         """Load input file."""

--- a/pd_utils/close_old_incidents.py
+++ b/pd_utils/close_old_incidents.py
@@ -16,10 +16,6 @@ from pd_utils.util import RuntimeInit
 
 NOW = datetime.datetime.utcnow()
 
-runtime = RuntimeInit("close-old-incidents")
-runtime.init_secrets()
-runtime.init_logging()
-
 
 class IncidentRow(TypedDict):
     incident_url: str
@@ -216,13 +212,45 @@ class CloseOldIncidents:
         return resp.json()["log_entries"][0]
 
 
-if __name__ == "__main__":
+def main(args_in: list[str] | None = None) -> int:
+    """Run the script."""
+    runtime = RuntimeInit("close-old-incidents")
+    runtime.init_secrets()
+    runtime.add_standard_arguments()
+    runtime.add_argument(
+        "--inputfile",
+        "",
+        "Provide a csv file to work from. If not provided a new file will be created.",
+    )
+    runtime.add_argument(
+        flag="--close-after-days",
+        default="10",
+        help_="Incidents older than this are considered for closing",
+    )
+    runtime.parser.add_argument(
+        "--close-active",
+        action="store_true",
+        help="When present, old incidents are closed regardless of activity",
+    )
+    runtime.parser.add_argument(
+        "--close-priority",
+        action="store_true",
+        help="When present, consider incidents with priority for closing",
+    )
+    runtime.init_logging()
+    args = runtime.parse_args(args_in)
+
     client = CloseOldIncidents(
         token=runtime.secrets.get("PAGERDUTY_TOKEN"),
         email=runtime.secrets.get("PAGERDUTY_EMAIL"),
+        close_after_days=int(args.close_after_days),
+        close_active=args.close_active,
+        close_priority=args.close_priority,
     )
-    resp = client._get_all_incidents()
-    for incident in resp:
-        client._get_newest_log_entry(incident.incident_id)
+    client.run(args.inputfile)
 
-    raise SystemExit()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pd_utils/model/__init__.py
+++ b/pd_utils/model/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from .escalation_rule_coverage import EscalationRuleCoverage
+from .incident import Incident
 from .schedule_coverage import ScheduleCoverage
 
 __all__ = [
     "EscalationRuleCoverage",
+    "Incident",
     "ScheduleCoverage",
 ]

--- a/pd_utils/model/incident.py
+++ b/pd_utils/model/incident.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+
+@dataclasses.dataclass
+class Incident:
+    incident_id: str
+    incident_number: int
+    title: str
+    created_at: str
+    status: str
+    last_status_change_at: str
+    has_priority: bool
+    urgency: str
+
+    @classmethod
+    def build_from(cls, resp: dict[str, Any]) -> Incident:
+        """Build Incident object from PagerDuty API response."""
+        return cls(
+            incident_id=resp["id"],
+            incident_number=resp["incident_number"],
+            title=resp["title"],
+            created_at=resp["created_at"],
+            status=resp["status"],
+            last_status_change_at=resp["last_status_change_at"],
+            has_priority=bool(resp["priority"]),
+            urgency=resp["urgency"],
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        """Convert object to dictionary."""
+        return dataclasses.asdict(self)

--- a/pd_utils/util/date_tool.py
+++ b/pd_utils/util/date_tool.py
@@ -17,6 +17,14 @@ class DateTool:
         return datetime.fromisoformat(isotime.rstrip("Z"))
 
     @staticmethod
+    def to_seconds(start: str, end: str) -> int:
+        """Find the number of seconds between two PD formated iso times."""
+        start_ = DateTool.to_datetime(start)
+        end_ = DateTool.to_datetime(end)
+        delta = end_ - start_
+        return delta.days * 86_400 + delta.seconds
+
+    @staticmethod
     def add_offset(
         isotime: str,
         *,

--- a/pd_utils/util/date_tool.py
+++ b/pd_utils/util/date_tool.py
@@ -12,6 +12,11 @@ class DateTool:
         return date_time.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     @staticmethod
+    def to_datetime(isotime: str) -> datetime:
+        """Covert PD formated iso time to unaware datetime."""
+        return datetime.fromisoformat(isotime.rstrip("Z"))
+
+    @staticmethod
     def add_offset(
         isotime: str,
         *,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pd-utils"
-version = "1.1.1"
+version = "1.2.0"
 requires-python = ">=3.8"
 description = "Utility scripts for PagerDuty instance administration and reporting."
 readme = "README.md"
@@ -55,6 +55,7 @@ homepage = "https://github.com/Preocts/pd-utils"
 coverage-gap-report = "pd_utils.coverage_gap_report:main"
 safelist-gatherer = "pd_utils.safelist_gatherer:console_output"
 simple-alert = "pd_utils.simple_alert:console_handler"
+close-old-incidents = "pd_utils.close_old_incidents:main"
 
 # [tool.setuptools.packages.find]
 # where = ["src"]  # ["."] by default

--- a/tests/close_old_incidents_test.py
+++ b/tests/close_old_incidents_test.py
@@ -189,7 +189,39 @@ def test_save_file(
 
     try:
         client._write_file(mock_incidents, mock_filename)
+
         assert filecheck.exists()
 
     finally:
         filecheck.unlink(True)
+
+
+def test_empty_save(monkeypatch: MonkeyPatch) -> None:
+    now = datetime.datetime(1999, 12, 25, 13, 50, 30, 0)
+    mock_dt = MagicMock(now=MagicMock(return_value=now))
+    monkeypatch.setattr(close_old_incidents.datetime, "datetime", mock_dt)
+    mock_filename = "temp_save_test"
+    filecheck = Path(f"{mock_filename}-{now.strftime('%Y%m%d-%H%M')}.csv")
+    client = close_old_incidents.CloseOldIncidents("mock", "mock")
+
+    try:
+        client._write_file([], mock_filename)
+
+        assert not filecheck.exists()
+
+    finally:
+        filecheck.unlink(True)
+
+
+def test_load_file(closer: CloseOldIncidents) -> None:
+    writefile = Path("temp_load_test.csv")
+    with writefile.open("w") as outfile:
+        outfile.write(MOCK_REPORT)
+
+    try:
+        result = closer._load_input_file(str(writefile))
+
+        assert len(result) == 4
+
+    finally:
+        writefile.unlink(True)

--- a/tests/close_old_incidents_test.py
+++ b/tests/close_old_incidents_test.py
@@ -225,3 +225,17 @@ def test_load_file(closer: CloseOldIncidents) -> None:
 
     finally:
         writefile.unlink(True)
+
+
+def test_run_empty_results(closer: CloseOldIncidents) -> None:
+    resp = Response(200, content='{"incidents": [], "more": false}')
+    with patch.object(closer._http, "get", return_value=resp):
+        closer.run()
+
+
+def test_run_empty_file(closer: CloseOldIncidents) -> None:
+    with patch.object(closer, "_load_input_file", return_value=[]) as mocked:
+        closer.run("mock_file")
+
+        assert mocked.call_count == 1
+        mocked.assert_called_with("mock_file")

--- a/tests/close_old_incidents_test.py
+++ b/tests/close_old_incidents_test.py
@@ -44,9 +44,9 @@ def closer() -> CloseOldIncidents:
 @pytest.fixture
 def mock_incidents() -> list[Incident]:
     now = DateTool.utcnow_isotime()
-    days5 = DateTool.add_offset(now, days=5)
-    days10 = DateTool.add_offset(now, days=9, minutes=58)
-    old = DateTool.add_offset(now, days=10, minutes=1)
+    days5 = DateTool.add_offset(now, days=-5)
+    days10 = DateTool.add_offset(now, days=-9, minutes=-58)
+    old = DateTool.add_offset(now, days=-10, minutes=-1)
     incs = [
         Incident("a", 1, "New", now, "triggered", now, True, "high"),
         Incident("b", 4, "Old", old, "triggered", old, False, "high"),

--- a/tests/close_old_incidents_test.py
+++ b/tests/close_old_incidents_test.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from httpx import Response
 
+from pd_utils import close_old_incidents
 from pd_utils.close_old_incidents import CloseOldIncidents
 from pd_utils.close_old_incidents import QueryError
 from pd_utils.model import Incident
@@ -117,3 +118,45 @@ def test_isolate_inactive_incidents(
 
     assert len(results) == 1
     assert results[0].incident_number == 4
+
+
+def test_main_no_optional_args() -> None:
+
+    with patch.object(close_old_incidents, "CloseOldIncidents") as mockclass:
+        close_old_incidents.main(["--token", "mock", "--email", "mock@mock.com"])
+        kwargs = mockclass.call_args.kwargs
+        print(mockclass.call_args.kwargs)
+
+    assert kwargs == {
+        "token": "mock",
+        "email": "mock@mock.com",
+        "close_after_days": 10,
+        "close_active": False,
+        "close_priority": False,
+    }
+
+
+def test_main_optional_args() -> None:
+
+    with patch.object(close_old_incidents, "CloseOldIncidents") as mockclass:
+        close_old_incidents.main(
+            [
+                "--token",
+                "mock",
+                "--email",
+                "mock@mock.com",
+                "--close-active",
+                "--close-priority",
+                "--close-after-days=5",
+            ]
+        )
+        kwargs = mockclass.call_args.kwargs
+        print(mockclass.call_args.kwargs)
+
+    assert kwargs == {
+        "token": "mock",
+        "email": "mock@mock.com",
+        "close_after_days": 5,
+        "close_active": True,
+        "close_priority": True,
+    }

--- a/tests/close_old_incidents_test.py
+++ b/tests/close_old_incidents_test.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from httpx import Response
+
+from pd_utils.close_old_incidents import CloseOldIncidents
+from pd_utils.close_old_incidents import QueryError
+
+
+INCIDENTS_RESP = Path("tests/fixture/close-incidents/incidents.json").read_text()
+EXPECTED_IDS = {"Q36LM3UBN4V94O", "Q3YH44AL350A23"}
+
+LOG_ENTRIES_RESP = Path("tests/fixture/close-incidents/logentry.json").read_text()
+EXPECTED_LOG_ID = "R15HMGZ64N39C61067KAZ68JIN"
+
+
+@pytest.fixture
+def closer() -> CloseOldIncidents:
+    return CloseOldIncidents("mock", "mock")
+
+
+def test_get_all_incidents(closer: CloseOldIncidents) -> None:
+    resps = json.loads(INCIDENTS_RESP)
+    resp = [Response(200, content=json.dumps(r)) for r in resps]
+
+    with patch.object(closer._http, "get", side_effect=resp) as mockhttp:
+
+        results = closer._get_all_incidents()
+
+    assert mockhttp.call_count == 2
+    assert not {i.incident_id for i in results} - EXPECTED_IDS
+
+
+def test_get_all_incidents_error(closer: CloseOldIncidents) -> None:
+    resp = [Response(404, content="Not Found")]
+
+    with patch.object(closer._http, "get", side_effect=resp):
+        with pytest.raises(QueryError):
+            closer._get_all_incidents()
+
+
+def test_get_newest_log_entry(closer: CloseOldIncidents) -> None:
+    resp = [Response(200, content=LOG_ENTRIES_RESP)]
+
+    with patch.object(closer._http, "get", side_effect=resp) as mockhttp:
+
+        results = closer._get_newest_log_entry("mock")
+
+    assert mockhttp.call_count == 1
+    assert results["id"] == EXPECTED_LOG_ID
+
+
+def test_get_newest_log_entry_error(closer: CloseOldIncidents) -> None:
+    resp = [Response(404, content="Not Found")]
+
+    with patch.object(closer._http, "get", side_effect=resp):
+        with pytest.raises(QueryError):
+            closer._get_newest_log_entry("mock")

--- a/tests/fixture/close-incidents/incidents.json
+++ b/tests/fixture/close-incidents/incidents.json
@@ -1,0 +1,323 @@
+[
+    {
+        "incidents": [
+            {
+                "incident_number": 1,
+                "title": "This is a test",
+                "description": "This is a test",
+                "created_at": "2022-07-31T02:36:20Z",
+                "status": "resolved",
+                "incident_key": null,
+                "service": {
+                    "id": "PIF0WEL",
+                    "type": "service_reference",
+                    "summary": "Testing service",
+                    "self": "https://api.pagerduty.com/services/PIF0WEL",
+                    "html_url": "https://preocts.pagerduty.com/service-directory/PIF0WEL"
+                },
+                "assignments": [],
+                "assigned_via": "escalation_policy",
+                "last_status_change_at": "2022-07-31T04:34:44Z",
+                "first_trigger_log_entry": {
+                    "id": "R3399UI736LWCN1NWVMIXDC55V",
+                    "type": "trigger_log_entry_reference",
+                    "summary": "Triggered through the API.",
+                    "self": "https://api.pagerduty.com/log_entries/R3399UI736LWCN1NWVMIXDC55V",
+                    "html_url": "https://preocts.pagerduty.com/incidents/Q28ZYJ9YPJ7XRN/log_entries/R3399UI736LWCN1NWVMIXDC55V"
+                },
+                "alert_counts": {
+                    "all": 3,
+                    "triggered": 0,
+                    "resolved": 3
+                },
+                "is_mergeable": true,
+                "escalation_policy": {
+                    "id": "P46S1RA",
+                    "type": "escalation_policy_reference",
+                    "summary": "Mind the gap",
+                    "self": "https://api.pagerduty.com/escalation_policies/P46S1RA",
+                    "html_url": "https://preocts.pagerduty.com/escalation_policies/P46S1RA"
+                },
+                "teams": [],
+                "pending_actions": [],
+                "acknowledgements": [],
+                "basic_alert_grouping": null,
+                "alert_grouping": {
+                    "grouping_type": "advanced",
+                    "started_at": "2022-07-31T02:36:20Z",
+                    "ended_at": "2022-07-31T04:34:44Z",
+                    "alert_grouping_active": false
+                },
+                "last_status_change_by": {
+                    "id": "PSIUGWW",
+                    "type": "user_reference",
+                    "summary": "Preocts",
+                    "self": "https://api.pagerduty.com/users/PSIUGWW",
+                    "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
+                },
+                "priority": null,
+                "resolve_reason": null,
+                "incidents_responders": [],
+                "responder_requests": [],
+                "subscriber_requests": [],
+                "urgency": "high",
+                "id": "Q28ZYJ9YPJ7XRN",
+                "type": "incident",
+                "summary": "[#1] This is a test",
+                "self": "https://api.pagerduty.com/incidents/Q28ZYJ9YPJ7XRN",
+                "html_url": "https://preocts.pagerduty.com/incidents/Q28ZYJ9YPJ7XRN"
+            }
+        ],
+        "limit": 1,
+        "offset": 0,
+        "total": null,
+        "more": true
+    },
+    {
+        "incidents": [
+            {
+                "incident_number": 2,
+                "title": "Example Incident",
+                "description": "Example Incident",
+                "created_at": "2022-07-31T04:35:03Z",
+                "status": "resolved",
+                "incident_key": "cbea81847c054d2ab63ba70e50426ceb",
+                "service": {
+                    "id": "P4CVCNH",
+                    "type": "service_reference",
+                    "summary": "test",
+                    "self": "https://api.pagerduty.com/services/P4CVCNH",
+                    "html_url": "https://preocts.pagerduty.com/service-directory/P4CVCNH"
+                },
+                "assignments": [],
+                "assigned_via": "escalation_policy",
+                "last_status_change_at": "2022-07-31T04:35:37Z",
+                "first_trigger_log_entry": {
+                    "id": "RPBSA4C2A25S1XC0Z3THU9NB91",
+                    "type": "trigger_log_entry_reference",
+                    "summary": "Triggered through the website.",
+                    "self": "https://api.pagerduty.com/log_entries/RPBSA4C2A25S1XC0Z3THU9NB91",
+                    "html_url": "https://preocts.pagerduty.com/incidents/Q1IA1GMYQ8SGVR/log_entries/RPBSA4C2A25S1XC0Z3THU9NB91"
+                },
+                "alert_counts": {
+                    "all": 0,
+                    "triggered": 0,
+                    "resolved": 0
+                },
+                "is_mergeable": true,
+                "escalation_policy": {
+                    "id": "P46S1RA",
+                    "type": "escalation_policy_reference",
+                    "summary": "Mind the gap",
+                    "self": "https://api.pagerduty.com/escalation_policies/P46S1RA",
+                    "html_url": "https://preocts.pagerduty.com/escalation_policies/P46S1RA"
+                },
+                "teams": [],
+                "pending_actions": [],
+                "acknowledgements": [],
+                "basic_alert_grouping": null,
+                "alert_grouping": null,
+                "last_status_change_by": {
+                    "id": "PSIUGWW",
+                    "type": "user_reference",
+                    "summary": "Preocts",
+                    "self": "https://api.pagerduty.com/users/PSIUGWW",
+                    "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
+                },
+                "priority": null,
+                "resolve_reason": null,
+                "incidents_responders": [],
+                "responder_requests": [],
+                "subscriber_requests": [],
+                "urgency": "high",
+                "id": "Q1IA1GMYQ8SGVR",
+                "type": "incident",
+                "summary": "[#2] Example Incident",
+                "self": "https://api.pagerduty.com/incidents/Q1IA1GMYQ8SGVR",
+                "html_url": "https://preocts.pagerduty.com/incidents/Q1IA1GMYQ8SGVR"
+            },
+            {
+                "incident_number": 3,
+                "title": "This has no priority",
+                "description": "This has no priority",
+                "created_at": "2022-08-01T02:38:25Z",
+                "status": "acknowledged",
+                "incident_key": "e83780a13e4a466e941f3f0e55ef2e6e",
+                "service": {
+                    "id": "PIF0WEL",
+                    "type": "service_reference",
+                    "summary": "Testing service",
+                    "self": "https://api.pagerduty.com/services/PIF0WEL",
+                    "html_url": "https://preocts.pagerduty.com/service-directory/PIF0WEL"
+                },
+                "assignments": [
+                    {
+                        "at": "2022-08-01T02:38:25Z",
+                        "assignee": {
+                            "id": "PSIUGWW",
+                            "type": "user_reference",
+                            "summary": "Preocts",
+                            "self": "https://api.pagerduty.com/users/PSIUGWW",
+                            "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
+                        }
+                    }
+                ],
+                "assigned_via": "escalation_policy",
+                "last_status_change_at": "2022-08-01T02:39:15Z",
+                "first_trigger_log_entry": {
+                    "id": "R2MAIUM5K4Y158HB612DX6UPXK",
+                    "type": "trigger_log_entry_reference",
+                    "summary": "Triggered through the website.",
+                    "self": "https://api.pagerduty.com/log_entries/R2MAIUM5K4Y158HB612DX6UPXK",
+                    "html_url": "https://preocts.pagerduty.com/incidents/Q36LM3UBN4V94O/log_entries/R2MAIUM5K4Y158HB612DX6UPXK"
+                },
+                "alert_counts": {
+                    "all": 0,
+                    "triggered": 0,
+                    "resolved": 0
+                },
+                "is_mergeable": true,
+                "escalation_policy": {
+                    "id": "P46S1RA",
+                    "type": "escalation_policy_reference",
+                    "summary": "Mind the gap",
+                    "self": "https://api.pagerduty.com/escalation_policies/P46S1RA",
+                    "html_url": "https://preocts.pagerduty.com/escalation_policies/P46S1RA"
+                },
+                "teams": [],
+                "pending_actions": [],
+                "acknowledgements": [
+                    {
+                        "at": "2022-08-01T02:39:15Z",
+                        "acknowledger": {
+                            "id": "PSIUGWW",
+                            "type": "user_reference",
+                            "summary": "Preocts",
+                            "self": "https://api.pagerduty.com/users/PSIUGWW",
+                            "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
+                        }
+                    }
+                ],
+                "basic_alert_grouping": null,
+                "alert_grouping": null,
+                "last_status_change_by": {
+                    "id": "PSIUGWW",
+                    "type": "user_reference",
+                    "summary": "Preocts",
+                    "self": "https://api.pagerduty.com/users/PSIUGWW",
+                    "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
+                },
+                "priority": null,
+                "incidents_responders": [],
+                "responder_requests": [],
+                "subscriber_requests": [],
+                "urgency": "high",
+                "id": "Q36LM3UBN4V94O",
+                "type": "incident",
+                "summary": "[#3] This has no priority",
+                "self": "https://api.pagerduty.com/incidents/Q36LM3UBN4V94O",
+                "html_url": "https://preocts.pagerduty.com/incidents/Q36LM3UBN4V94O"
+            },
+            {
+                "incident_number": 4,
+                "title": "This has priority",
+                "description": "This has priority",
+                "created_at": "2022-08-01T02:38:38Z",
+                "status": "acknowledged",
+                "incident_key": "c6f8be7c40344ed4b99a035cc1ab4271",
+                "service": {
+                    "id": "PIF0WEL",
+                    "type": "service_reference",
+                    "summary": "Testing service",
+                    "self": "https://api.pagerduty.com/services/PIF0WEL",
+                    "html_url": "https://preocts.pagerduty.com/service-directory/PIF0WEL"
+                },
+                "assignments": [
+                    {
+                        "at": "2022-08-01T02:38:38Z",
+                        "assignee": {
+                            "id": "PSIUGWW",
+                            "type": "user_reference",
+                            "summary": "Preocts",
+                            "self": "https://api.pagerduty.com/users/PSIUGWW",
+                            "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
+                        }
+                    }
+                ],
+                "assigned_via": "escalation_policy",
+                "last_status_change_at": "2022-08-01T02:39:10Z",
+                "first_trigger_log_entry": {
+                    "id": "RRNQDXO8SSOW8LLNA7FPDQHOHZ",
+                    "type": "trigger_log_entry_reference",
+                    "summary": "Triggered through the website.",
+                    "self": "https://api.pagerduty.com/log_entries/RRNQDXO8SSOW8LLNA7FPDQHOHZ",
+                    "html_url": "https://preocts.pagerduty.com/incidents/Q3YH44AL350A23/log_entries/RRNQDXO8SSOW8LLNA7FPDQHOHZ"
+                },
+                "alert_counts": {
+                    "all": 0,
+                    "triggered": 0,
+                    "resolved": 0
+                },
+                "is_mergeable": true,
+                "escalation_policy": {
+                    "id": "P46S1RA",
+                    "type": "escalation_policy_reference",
+                    "summary": "Mind the gap",
+                    "self": "https://api.pagerduty.com/escalation_policies/P46S1RA",
+                    "html_url": "https://preocts.pagerduty.com/escalation_policies/P46S1RA"
+                },
+                "teams": [],
+                "pending_actions": [],
+                "acknowledgements": [
+                    {
+                        "at": "2022-08-01T02:39:10Z",
+                        "acknowledger": {
+                            "id": "PSIUGWW",
+                            "type": "user_reference",
+                            "summary": "Preocts",
+                            "self": "https://api.pagerduty.com/users/PSIUGWW",
+                            "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
+                        }
+                    }
+                ],
+                "basic_alert_grouping": null,
+                "alert_grouping": null,
+                "last_status_change_by": {
+                    "id": "PSIUGWW",
+                    "type": "user_reference",
+                    "summary": "Preocts",
+                    "self": "https://api.pagerduty.com/users/PSIUGWW",
+                    "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
+                },
+                "priority": {
+                    "id": "P7KL9IW",
+                    "type": "priority",
+                    "summary": "P1",
+                    "self": "https://api.pagerduty.com/priorities/P7KL9IW",
+                    "html_url": null,
+                    "account_id": "PNKL2XW",
+                    "color": "a8171c",
+                    "created_at": "2022-08-01T02:38:58Z",
+                    "description": "",
+                    "name": "P1",
+                    "order": 67108864,
+                    "schema_version": 0,
+                    "updated_at": "2022-08-01T02:38:58Z"
+                },
+                "incidents_responders": [],
+                "responder_requests": [],
+                "subscriber_requests": [],
+                "urgency": "high",
+                "id": "Q3YH44AL350A23",
+                "type": "incident",
+                "summary": "[#4] This has priority",
+                "self": "https://api.pagerduty.com/incidents/Q3YH44AL350A23",
+                "html_url": "https://preocts.pagerduty.com/incidents/Q3YH44AL350A23"
+            }
+        ],
+        "limit": 1,
+        "offset": 1,
+        "total": null,
+        "more": false
+    }
+]

--- a/tests/fixture/close-incidents/incidents.json
+++ b/tests/fixture/close-incidents/incidents.json
@@ -2,141 +2,6 @@
     {
         "incidents": [
             {
-                "incident_number": 1,
-                "title": "This is a test",
-                "description": "This is a test",
-                "created_at": "2022-07-31T02:36:20Z",
-                "status": "resolved",
-                "incident_key": null,
-                "service": {
-                    "id": "PIF0WEL",
-                    "type": "service_reference",
-                    "summary": "Testing service",
-                    "self": "https://api.pagerduty.com/services/PIF0WEL",
-                    "html_url": "https://preocts.pagerduty.com/service-directory/PIF0WEL"
-                },
-                "assignments": [],
-                "assigned_via": "escalation_policy",
-                "last_status_change_at": "2022-07-31T04:34:44Z",
-                "first_trigger_log_entry": {
-                    "id": "R3399UI736LWCN1NWVMIXDC55V",
-                    "type": "trigger_log_entry_reference",
-                    "summary": "Triggered through the API.",
-                    "self": "https://api.pagerduty.com/log_entries/R3399UI736LWCN1NWVMIXDC55V",
-                    "html_url": "https://preocts.pagerduty.com/incidents/Q28ZYJ9YPJ7XRN/log_entries/R3399UI736LWCN1NWVMIXDC55V"
-                },
-                "alert_counts": {
-                    "all": 3,
-                    "triggered": 0,
-                    "resolved": 3
-                },
-                "is_mergeable": true,
-                "escalation_policy": {
-                    "id": "P46S1RA",
-                    "type": "escalation_policy_reference",
-                    "summary": "Mind the gap",
-                    "self": "https://api.pagerduty.com/escalation_policies/P46S1RA",
-                    "html_url": "https://preocts.pagerduty.com/escalation_policies/P46S1RA"
-                },
-                "teams": [],
-                "pending_actions": [],
-                "acknowledgements": [],
-                "basic_alert_grouping": null,
-                "alert_grouping": {
-                    "grouping_type": "advanced",
-                    "started_at": "2022-07-31T02:36:20Z",
-                    "ended_at": "2022-07-31T04:34:44Z",
-                    "alert_grouping_active": false
-                },
-                "last_status_change_by": {
-                    "id": "PSIUGWW",
-                    "type": "user_reference",
-                    "summary": "Preocts",
-                    "self": "https://api.pagerduty.com/users/PSIUGWW",
-                    "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
-                },
-                "priority": null,
-                "resolve_reason": null,
-                "incidents_responders": [],
-                "responder_requests": [],
-                "subscriber_requests": [],
-                "urgency": "high",
-                "id": "Q28ZYJ9YPJ7XRN",
-                "type": "incident",
-                "summary": "[#1] This is a test",
-                "self": "https://api.pagerduty.com/incidents/Q28ZYJ9YPJ7XRN",
-                "html_url": "https://preocts.pagerduty.com/incidents/Q28ZYJ9YPJ7XRN"
-            }
-        ],
-        "limit": 1,
-        "offset": 0,
-        "total": null,
-        "more": true
-    },
-    {
-        "incidents": [
-            {
-                "incident_number": 2,
-                "title": "Example Incident",
-                "description": "Example Incident",
-                "created_at": "2022-07-31T04:35:03Z",
-                "status": "resolved",
-                "incident_key": "cbea81847c054d2ab63ba70e50426ceb",
-                "service": {
-                    "id": "P4CVCNH",
-                    "type": "service_reference",
-                    "summary": "test",
-                    "self": "https://api.pagerduty.com/services/P4CVCNH",
-                    "html_url": "https://preocts.pagerduty.com/service-directory/P4CVCNH"
-                },
-                "assignments": [],
-                "assigned_via": "escalation_policy",
-                "last_status_change_at": "2022-07-31T04:35:37Z",
-                "first_trigger_log_entry": {
-                    "id": "RPBSA4C2A25S1XC0Z3THU9NB91",
-                    "type": "trigger_log_entry_reference",
-                    "summary": "Triggered through the website.",
-                    "self": "https://api.pagerduty.com/log_entries/RPBSA4C2A25S1XC0Z3THU9NB91",
-                    "html_url": "https://preocts.pagerduty.com/incidents/Q1IA1GMYQ8SGVR/log_entries/RPBSA4C2A25S1XC0Z3THU9NB91"
-                },
-                "alert_counts": {
-                    "all": 0,
-                    "triggered": 0,
-                    "resolved": 0
-                },
-                "is_mergeable": true,
-                "escalation_policy": {
-                    "id": "P46S1RA",
-                    "type": "escalation_policy_reference",
-                    "summary": "Mind the gap",
-                    "self": "https://api.pagerduty.com/escalation_policies/P46S1RA",
-                    "html_url": "https://preocts.pagerduty.com/escalation_policies/P46S1RA"
-                },
-                "teams": [],
-                "pending_actions": [],
-                "acknowledgements": [],
-                "basic_alert_grouping": null,
-                "alert_grouping": null,
-                "last_status_change_by": {
-                    "id": "PSIUGWW",
-                    "type": "user_reference",
-                    "summary": "Preocts",
-                    "self": "https://api.pagerduty.com/users/PSIUGWW",
-                    "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
-                },
-                "priority": null,
-                "resolve_reason": null,
-                "incidents_responders": [],
-                "responder_requests": [],
-                "subscriber_requests": [],
-                "urgency": "high",
-                "id": "Q1IA1GMYQ8SGVR",
-                "type": "incident",
-                "summary": "[#2] Example Incident",
-                "self": "https://api.pagerduty.com/incidents/Q1IA1GMYQ8SGVR",
-                "html_url": "https://preocts.pagerduty.com/incidents/Q1IA1GMYQ8SGVR"
-            },
-            {
                 "incident_number": 3,
                 "title": "This has no priority",
                 "description": "This has no priority",
@@ -217,7 +82,15 @@
                 "summary": "[#3] This has no priority",
                 "self": "https://api.pagerduty.com/incidents/Q36LM3UBN4V94O",
                 "html_url": "https://preocts.pagerduty.com/incidents/Q36LM3UBN4V94O"
-            },
+            }
+        ],
+        "limit": 1,
+        "offset": 0,
+        "total": null,
+        "more": true
+    },
+    {
+        "incidents": [
             {
                 "incident_number": 4,
                 "title": "This has priority",

--- a/tests/fixture/close-incidents/logentry.json
+++ b/tests/fixture/close-incidents/logentry.json
@@ -1,0 +1,43 @@
+{
+    "log_entries": [
+        {
+            "id": "R15HMGZ64N39C61067KAZ68JIN",
+            "type": "annotate_log_entry",
+            "summary": "Note added by Preocts.",
+            "self": "https://api.pagerduty.com/log_entries/R15HMGZ64N39C61067KAZ68JIN",
+            "html_url": null,
+            "created_at": "2022-08-01T03:10:19Z",
+            "agent": {
+                "id": "PSIUGWW",
+                "type": "user_reference",
+                "summary": "Preocts",
+                "self": "https://api.pagerduty.com/users/PSIUGWW",
+                "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
+            },
+            "channel": {
+                "type": "note",
+                "summary": "Something something note"
+            },
+            "service": {
+                "id": "PIF0WEL",
+                "type": "service_reference",
+                "summary": "Testing service",
+                "self": "https://api.pagerduty.com/services/PIF0WEL",
+                "html_url": "https://preocts.pagerduty.com/service-directory/PIF0WEL"
+            },
+            "incident": {
+                "id": "Q3YH44AL350A23",
+                "type": "incident_reference",
+                "summary": "[#4] This has priority",
+                "self": "https://api.pagerduty.com/incidents/Q3YH44AL350A23",
+                "html_url": "https://preocts.pagerduty.com/incidents/Q3YH44AL350A23"
+            },
+            "teams": [],
+            "contexts": []
+        }
+    ],
+    "limit": 1,
+    "offset": 0,
+    "more": true,
+    "total": null
+}

--- a/tests/model/incident_test.py
+++ b/tests/model/incident_test.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pd_utils.model import Incident
+
+SCHEDULE = Path("tests/fixture/close-incidents/incidents.json").read_text()
+
+
+def test_model() -> None:
+    resp = json.loads(SCHEDULE)[0]["incidents"][0]
+
+    model = Incident.build_from(resp)
+    dct = model.as_dict()
+
+    assert dct["incident_id"] == "Q28ZYJ9YPJ7XRN"
+    assert model.incident_number == 1
+    assert model.title == "This is a test"
+    assert model.created_at == "2022-07-31T02:36:20Z"
+    assert model.status == "resolved"
+    assert model.last_status_change_at == "2022-07-31T04:34:44Z"
+    assert model.has_priority is False
+    assert model.urgency == "high"

--- a/tests/model/incident_test.py
+++ b/tests/model/incident_test.py
@@ -14,11 +14,11 @@ def test_model() -> None:
     model = Incident.build_from(resp)
     dct = model.as_dict()
 
-    assert dct["incident_id"] == "Q28ZYJ9YPJ7XRN"
-    assert model.incident_number == 1
-    assert model.title == "This is a test"
-    assert model.created_at == "2022-07-31T02:36:20Z"
-    assert model.status == "resolved"
-    assert model.last_status_change_at == "2022-07-31T04:34:44Z"
+    assert dct["incident_id"] == "Q36LM3UBN4V94O"
+    assert model.incident_number == 3
+    assert model.title == "This has no priority"
+    assert model.created_at == "2022-08-01T02:38:25Z"
+    assert model.status == "acknowledged"
+    assert model.last_status_change_at == "2022-08-01T02:39:15Z"
     assert model.has_priority is False
     assert model.urgency == "high"

--- a/tests/util/date_tool_test.py
+++ b/tests/util/date_tool_test.py
@@ -143,3 +143,19 @@ def test_is_covered(
     expected: bool,
 ) -> None:
     assert DateTool.is_covered(time_slots, start, stop) is expected
+
+
+@pytest.mark.parametrize(
+    ("from_", "to_", "expected"),
+    (
+        ("2022-12-25T13:50:30Z", "2022-12-25T13:51:00Z", 30),
+        ("2022-12-25T13:50:30Z", "2022-12-26T13:49:30Z", 86_340),
+        ("2022-12-25T13:50:30Z", "2022-12-26T13:51:30Z", 86_460),
+        ("2022-12-25T13:50:30Z", "2022-12-26T13:50:30Z", 86_400),
+        ("2022-12-25T13:50:30Z", "2022-12-25T13:50:30Z", 0),
+    ),
+)
+def test_to_seconds(from_: str, to_: str, expected: int) -> None:
+    result = DateTool.to_seconds(from_, to_)
+
+    assert result == expected

--- a/tests/util/date_tool_test.py
+++ b/tests/util/date_tool_test.py
@@ -26,6 +26,13 @@ def test_to_isotime() -> None:
     assert result == MOCK_ISO
 
 
+def test_to_datetime() -> None:
+    result = DateTool.to_datetime(MOCK_ISO)
+
+    assert result == MOCK_NOW
+    assert result.tzinfo is None
+
+
 def test_utcnow_isotime(patch_datetime_utcnow: None) -> None:
 
     result = date_tool.DateTool.utcnow_isotime()

--- a/tests/util/date_tool_test.py
+++ b/tests/util/date_tool_test.py
@@ -62,6 +62,10 @@ def test_add_offset() -> None:
             ],
             True,
         ),
+        (
+            [],
+            False,
+        ),
     ),
 )
 def test_is_gapless(time_slots: list[tuple[str, str]], expected: bool) -> None:
@@ -117,6 +121,12 @@ def test_is_gapless(time_slots: list[tuple[str, str]], expected: bool) -> None:
             "2022-08-01T00:00:00Z",
             True,
         ),
+        (  # Test: Edge case, this actually should never happen
+            [],
+            "2022-07-29T04:18:19Z",
+            "2022-08-01T00:00:00Z",
+            False,
+        ),
     ),
 )
 def test_is_covered(
@@ -126,10 +136,3 @@ def test_is_covered(
     expected: bool,
 ) -> None:
     assert DateTool.is_covered(time_slots, start, stop) is expected
-
-
-def test_is_gapless_empty_list() -> None:
-    # Edge case
-    result = DateTool._is_gapless([])
-
-    assert result is False


### PR DESCRIPTION
Create a tool for closing stale and ignored incidents. Unfortunately this will not solve the true issue, but just clean up the instance.

Default run will close all incidents that are:
- older than N days
- do not have a priority assigned
- have no activity within the last N days