### PR TITLE
HTTPS util for PagerDuty queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 # Script outputs
 schedule_gap_report*
 escalation_rule_gap_report*
+close-old-incidents-*.csv

--- a/pd_utils/util/__init__.py
+++ b/pd_utils/util/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from .date_tool import DateTool
+from .pagerduty_query import PagerDutyQuery
 from .runtime_init import RuntimeInit
 
 __all__ = [
     "DateTool",
+    "PagerDutyQuery",
     "RuntimeInit",
 ]

--- a/pd_utils/util/pagerduty_query.py
+++ b/pd_utils/util/pagerduty_query.py
@@ -16,13 +16,14 @@ class PagerDutyQuery:
     class QueryError(Exception):
         ...
 
-    def __init__(self, token: str, email: str) -> None:
+    def __init__(self, token: str, email: str | None = None) -> None:
         """Initilize httpx client for queries to list endpoints."""
         headers = {
             "Accept": "application/vnd.pagerduty+json;version=2",
             "Authorization": f"Token token={token}",
-            "From": email,
         }
+        headers.update({"From": email} if email else {})
+
         self._http = httpx.Client(headers=headers)
         self._params: dict[str, Any] = {}
         self._route: str | None = None

--- a/pd_utils/util/pagerduty_query.py
+++ b/pd_utils/util/pagerduty_query.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+import httpx
+
+
+class PagerDutyQuery:
+    """Pull from API list endpoints."""
+
+    def __init__(self, token: str, email: str) -> None:
+        """Initilize httpx client for queries to list endpoints."""
+        headers = {
+            "Accept": "application/vnd.pagerduty+json;version=2",
+            "Authorization": f"Token token={token}",
+            "From": email,
+        }
+        self._httpx = httpx.Client(headers=headers)
+        self._fields: Mapping[str, str | list[str] | bool] = {}
+        self._route: str | None = None
+        self._object_name: str | None = None
+
+    @property
+    def object_name(self) -> str:
+        """Object being returned by query."""
+        if not self._object_name:
+            raise ValueError("Object name not set.")
+        return self._object_name
+
+    @property
+    def route(self) -> str:
+        """Route being queried."""
+        if not self._route:
+            raise ValueError("Route not set.")
+        return self._route
+
+    def set_query_fields(self, fields: Mapping[str, str | list[str] | bool]) -> None:
+        """Set url fields for query."""
+        self._fields = fields
+
+    def set_query_target(self, route: str, object_name: str) -> None:
+        """
+        Set the route and object name for the query.
+
+        Args:
+            route: Examples: `/schedules` `/users` `/incident/{id}/log_entries`
+            object_name: Examples: `schedules`, `users`, `log_entries`
+        """
+        if not route.startswith("/"):
+            raise ValueError("Invalid route, must start with '/'.")
+
+        self._route = route
+        self._object_name = object_name

--- a/pd_utils/util/pagerduty_query.py
+++ b/pd_utils/util/pagerduty_query.py
@@ -95,8 +95,8 @@ class PagerDutyQuery:
             self.log.error("Unexpected error: %s", resp.text)
             raise self.QueryError("Unexpected error")
 
-        more_: bool = resp.json()["more"]
-        total_: int = resp.json()["total"] or 0
+        more_: bool = resp.json().get("more") or False
+        total_: int = resp.json().get("total") or 0
 
         self.log.debug("Pulled %d objects.", len(resp.json()[self.object_name]))
 

--- a/tests/close_old_incidents_test.py
+++ b/tests/close_old_incidents_test.py
@@ -13,16 +13,10 @@ from httpx import Response
 
 from pd_utils import close_old_incidents
 from pd_utils.close_old_incidents import CloseOldIncidents
-from pd_utils.close_old_incidents import QueryError
 from pd_utils.model import Incident
 from pd_utils.util import DateTool
 
-
-INCIDENTS_RESP = Path("tests/fixture/close-incidents/incidents.json").read_text()
-EXPECTED_IDS = {"Q36LM3UBN4V94O", "Q3YH44AL350A23"}
-
 LOG_ENTRIES_RESP = Path("tests/fixture/close-incidents/logentry.json").read_text()
-EXPECTED_LOG_ID = "R15HMGZ64N39C61067KAZ68JIN"
 
 # Built from the mock objects in fixture mock_incidents()
 MOCK_REPORT = "\n".join(
@@ -55,45 +49,6 @@ def mock_incidents() -> list[Incident]:
     ]
 
     return incs
-
-
-def test_get_all_incidents(closer: CloseOldIncidents) -> None:
-    resps = json.loads(INCIDENTS_RESP)
-    resp = [Response(200, content=json.dumps(r)) for r in resps]
-
-    with patch.object(closer._http, "get", side_effect=resp) as mockhttp:
-
-        results = closer._get_all_incidents()
-
-    assert mockhttp.call_count == 2
-    assert not {i.incident_id for i in results} - EXPECTED_IDS
-
-
-def test_get_all_incidents_error(closer: CloseOldIncidents) -> None:
-    resp = [Response(404, content="Not Found")]
-
-    with patch.object(closer._http, "get", side_effect=resp):
-        with pytest.raises(QueryError):
-            closer._get_all_incidents()
-
-
-def test_get_newest_log_entry(closer: CloseOldIncidents) -> None:
-    resp = [Response(200, content=LOG_ENTRIES_RESP)]
-
-    with patch.object(closer._http, "get", side_effect=resp) as mockhttp:
-
-        results = closer._get_newest_log_entry("mock")
-
-    assert mockhttp.call_count == 1
-    assert results["id"] == EXPECTED_LOG_ID
-
-
-def test_get_newest_log_entry_error(closer: CloseOldIncidents) -> None:
-    resp = [Response(404, content="Not Found")]
-
-    with patch.object(closer._http, "get", side_effect=resp):
-        with pytest.raises(QueryError):
-            closer._get_newest_log_entry("mock")
 
 
 def test_isolate_old_incidents(
@@ -264,7 +219,8 @@ def test_close_incidents(
 
 def test_run_empty_results(closer: CloseOldIncidents) -> None:
     resp = Response(200, content='{"incidents": [], "more": false}')
-    with patch.object(closer._http, "get", return_value=resp) as http:
+    # with patch.object(closer._http, "get", return_value=resp) as http:
+    with patch.object(closer._query._http, "get", return_value=resp) as http:
         closer.run()
 
         assert http.call_count == 1
@@ -273,7 +229,8 @@ def test_run_empty_results(closer: CloseOldIncidents) -> None:
 def test_run_empty_ignore_activity(closer: CloseOldIncidents) -> None:
     closer._close_active = True
     resp = Response(200, content='{"incidents": [], "more": false}')
-    with patch.object(closer._http, "get", return_value=resp):
+    with patch.object(closer._query._http, "get", return_value=resp):
+        # with patch.object(closer._http, "get", return_value=resp):
         with patch.object(closer, "_isolate_inactive_incidents") as avoid:
             closer.run()
 

--- a/tests/coverage_gap_report_test.py
+++ b/tests/coverage_gap_report_test.py
@@ -9,7 +9,6 @@ from httpx import Response
 
 from pd_utils import coverage_gap_report
 from pd_utils.coverage_gap_report import CoverageGapReport
-from pd_utils.coverage_gap_report import QueryError
 from pd_utils.model import ScheduleCoverage
 from pd_utils.model.escalation_rule_coverage import EscalationRuleCoverage
 
@@ -117,46 +116,6 @@ def mapped_search(search: CoverageGapReport) -> CoverageGapReport:
     return search
 
 
-def test_get_all_schedule_ids(search: CoverageGapReport) -> None:
-    resp_jsons = json.loads(SCHEDULES_RESP)
-    resps = [Response(200, content=json.dumps(resp)) for resp in resp_jsons]
-    with patch.object(search._http, "get", side_effect=resps):
-
-        results = search._get_all_schedule_ids()
-
-    assert not results - EXPECTED_IDS
-
-
-def test_get_all_escalations(search: CoverageGapReport) -> None:
-    resp_jsons = json.loads(EP_RESP)
-    resps = [Response(200, content=json.dumps(resp)) for resp in resp_jsons]
-    with patch.object(search._http, "get", side_effect=resps):
-
-        results = search._get_all_escalations()
-
-    assert len(results) == EP_EXPECTED_COUNT
-
-
-def test_get_all_schedules_error(search: CoverageGapReport) -> None:
-    resps = [Response(401, content="")]
-
-    with patch.object(search._http, "get", side_effect=resps):
-
-        with pytest.raises(QueryError):
-
-            search._get_all_schedule_ids()
-
-
-def test_get_all_escalations_error(search: CoverageGapReport) -> None:
-    resps = [Response(401, content="")]
-
-    with patch.object(search._http, "get", side_effect=resps):
-
-        with pytest.raises(QueryError):
-
-            search._get_all_escalations()
-
-
 def test_get_schedule_coverage(search: CoverageGapReport) -> None:
     resps = [Response(200, content=SCHEDULE_RESP)]
     with patch.object(search._http, "get", side_effect=resps):
@@ -241,5 +200,5 @@ def test_run(search: CoverageGapReport) -> None:
         Response(200, content='{"escalation_policies": [], "more": false}'),
     ]
 
-    with patch.object(search._http, "get", side_effect=resps):
+    with patch.object(search._query._http, "get", side_effect=resps):
         search.run_reports()

--- a/tests/util/pagerduty_query_test.py
+++ b/tests/util/pagerduty_query_test.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from pd_utils.util import PagerDutyQuery
+
+# from unittest.mock import patch
+
+
+@pytest.fixture
+def query() -> PagerDutyQuery:
+    return PagerDutyQuery("mock", "mock")
+
+
+def test_unset_property_object_name_raises(query: PagerDutyQuery) -> None:
+    with pytest.raises(ValueError):
+        query.object_name
+
+
+def test_unset_property_route_raises(query: PagerDutyQuery) -> None:
+    with pytest.raises(ValueError):
+        query.route
+
+
+def test_set_query_fields(query: PagerDutyQuery) -> None:
+    fields = {"status[]": ["triggered", "resolved"]}
+    query.set_query_fields(fields)
+
+    assert query._fields == fields
+
+
+def test_set_query_target(query: PagerDutyQuery) -> None:
+    query.set_query_target("/schedules", "schedules")
+
+    assert query.route == "/schedules"
+    assert query.object_name == "schedules"
+
+
+def test_set_query_target_invalid(query: PagerDutyQuery) -> None:
+    with pytest.raises(ValueError):
+        query.set_query_target("schedules", "schedules")

--- a/tests/util/pagerduty_query_test.py
+++ b/tests/util/pagerduty_query_test.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
+from httpx import Response
 
 from pd_utils.util import PagerDutyQuery
 
-# from unittest.mock import patch
+INCIDENTS_RESP = Path("tests/fixture/close-incidents/incidents.json").read_text()
+EXPECTED_IDS = {"Q36LM3UBN4V94O", "Q3YH44AL350A23"}
 
 
 @pytest.fixture
@@ -22,11 +28,11 @@ def test_unset_property_route_raises(query: PagerDutyQuery) -> None:
         query.route
 
 
-def test_set_query_fields(query: PagerDutyQuery) -> None:
-    fields = {"status[]": ["triggered", "resolved"]}
-    query.set_query_fields(fields)
+def test_set_query_params(query: PagerDutyQuery) -> None:
+    params = {"status[]": ["triggered", "resolved"]}
+    query.set_query_params(params)
 
-    assert query._fields == fields
+    assert query._params == params
 
 
 def test_set_query_target(query: PagerDutyQuery) -> None:
@@ -39,3 +45,39 @@ def test_set_query_target(query: PagerDutyQuery) -> None:
 def test_set_query_target_invalid(query: PagerDutyQuery) -> None:
     with pytest.raises(ValueError):
         query.set_query_target("schedules", "schedules")
+
+
+def test_run_success(query: PagerDutyQuery) -> None:
+    resps = json.loads(INCIDENTS_RESP)
+    resp = [Response(200, content=json.dumps(resps[0]))]
+    query.set_query_target("/incidents", "incidents")
+
+    with patch.object(query._http, "get", side_effect=resp):
+        result, more, count = query.run()
+
+    assert more is True
+    assert count == 0
+    assert result[0]["id"] in EXPECTED_IDS
+
+
+def test_run_failure(query: PagerDutyQuery) -> None:
+    resp = [Response(400, content="")]
+    query.set_query_target("/incidents", "incidents")
+
+    with patch.object(query._http, "get", side_effect=resp):
+        with pytest.raises(query.QueryError):
+            query.run()
+
+
+def test_run_iter(query: PagerDutyQuery) -> None:
+    resps = json.loads(INCIDENTS_RESP)
+    resp = [Response(200, content=json.dumps(r)) for r in resps]
+    query.set_query_target("/incidents", "incidents")
+    results = []
+
+    with patch.object(query._http, "get", side_effect=resp):
+
+        for result in query.run_iter(limit=1):
+            results.extend(result)
+
+    assert not {r["id"] for r in results} - EXPECTED_IDS


### PR DESCRIPTION
Create a utility for queries in PagerDuty as the code is frequently duplicated. This gives us a controllable `.run()` for our own loops and an iterator `.run_iter()` for generation of queries.

Changes replace existing code with new utility.

closes #4 