### PR TITLE
Bug fix and code cleaning

### DIFF
--- a/pd_utils/report/coverage_gap_report.py
+++ b/pd_utils/report/coverage_gap_report.py
@@ -86,7 +86,7 @@ class CoverageGapReport:
         self._query.set_query_target("/escalation_policies", "escalation_policies")
         self._query.set_query_params({})
 
-        eps = [ep for ep in self._query.run_iter(self._max_query_limit)]
+        eps = [ep for ep in self._query.query_iter(self._max_query_limit)]
 
         self.log.info("Discovered %d escalation policies.", len(eps))
         return eps
@@ -96,7 +96,7 @@ class CoverageGapReport:
         self._query.set_query_target("/schedules", "schedules")
         self._query.set_query_params({})
 
-        sch_ids = [sch["id"] for sch in self._query.run_iter(self._max_query_limit)]
+        sch_ids = [sch["id"] for sch in self._query.query_iter(self._max_query_limit)]
 
         self.log.info("Discovered %d schedules.", len(sch_ids))
         return set(sch_ids)

--- a/pd_utils/report/coverage_gap_report.py
+++ b/pd_utils/report/coverage_gap_report.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import httpx
-
 from pd_utils.model import EscalationRuleCoverage as EscCoverage
 from pd_utils.model import ScheduleCoverage as SchCoverage
 from pd_utils.util import DateTool
@@ -41,12 +39,6 @@ class CoverageGapReport:
         self._schedule_map: dict[str, SchCoverage] = {}
         self._escalation_map: dict[str, EscCoverage] = {}
 
-        headers = {
-            "Accept": "application/vnd.pagerduty+json;version=2",
-            "Authorization": f"Token token={token}",
-        }
-
-        self._http = httpx.Client(headers=headers)
         self._query = PagerDutyQuery(token)
 
     def run_reports(self) -> tuple[str, str]:
@@ -72,12 +64,12 @@ class CoverageGapReport:
             "until": self._until,
             "time_zone": "Etc/UTC",
         }
-        resp = self._http.get(f"{self.base_url}/schedules/{schedule_id}", params=params)
+        result = self._query.get(f"/schedules/{schedule_id}", params=params)
 
-        if resp.is_success:
-            schobj = SchCoverage.build_from(resp.json())
+        if result:
+            schobj = SchCoverage.build_from(result)
         else:
-            self.log.error("Error fetching schedule %s - %s", schedule_id, resp.text)
+            self.log.error("Error fetching schedule %s", schedule_id)
 
         return schobj
 

--- a/pd_utils/report/user_report.py
+++ b/pd_utils/report/user_report.py
@@ -69,7 +69,7 @@ class UserReport:
 
         user_map: dict[str, UserReportRow] = {}
         teams: set[_Team] = set()
-        for resp in self._query.run_iter(limit=self._max_query_limit):
+        for resp in self._query.query_iter(limit=self._max_query_limit):
             user = UserReportRow.build_from(resp)
             user_map[user.id] = user
             teams = teams.union(self._extract_teams(resp["teams"]))
@@ -85,7 +85,7 @@ class UserReport:
         self._query.set_query_params({})
         self._query.set_query_target("/schedules", "schedules")
         users: set[str] = set()
-        for schedule in self._query.run_iter():
+        for schedule in self._query.query_iter():
             for user in schedule["users"] or []:
                 if "deleted_at" not in user:
                     users.add(user["id"])
@@ -107,7 +107,7 @@ class UserReport:
         user_teams: list[UserTeam] = []
         for team_name, team_id in teams:
             self._query.set_query_target(f"/teams/{team_id}/members", "members")
-            for member in self._query.run_iter(limit=self._max_query_limit):
+            for member in self._query.query_iter(limit=self._max_query_limit):
                 user_teams.append(
                     UserTeam(
                         user_id=member["user"]["id"],

--- a/pd_utils/tool/close_old_incidents.py
+++ b/pd_utils/tool/close_old_incidents.py
@@ -159,7 +159,7 @@ class CloseOldIncidents:
         self._query.set_query_target("/incidents", "incidents")
         self._query.set_query_params(params)
 
-        incidents = [inc for inc in self._query.run_iter(self._max_query_limit)]
+        incidents = [inc for inc in self._query.query_iter(self._max_query_limit)]
 
         self.log.info("Discovered %d incidents.", len(incidents))
         return [Incident.build_from(incident) for incident in incidents]
@@ -171,7 +171,7 @@ class CloseOldIncidents:
             object_name="log_entries",
         )
         self._query.set_query_params({"time_zone": "UTC"})
-        resp, _, _ = self._query.run(limit=1)
+        resp, _, _ = self._query._query(limit=1)
         return resp[0]
 
     def _close_incidents(

--- a/tests/fixture/user_report/schedules.json
+++ b/tests/fixture/user_report/schedules.json
@@ -27,6 +27,14 @@
                     "summary": "Not Preocts",
                     "self": "https://api.pagerduty.com/users/PSIUGWW",
                     "html_url": "https://preocts.pagerduty.com/users/PSIUGWW"
+                },
+                {
+                    "id": "PSIUGWX",
+                    "type": "user_reference",
+                    "summary": "Not Preocts",
+                    "self": null,
+                    "html_url": "https://preocts.pagerduty.com/users/PSIUGWW",
+                    "deleted_at": "2022-08-01T02:38:25Z"
                 }
             ],
             "escalation_policies": [],

--- a/tests/reports/coverage_gap_report_test.py
+++ b/tests/reports/coverage_gap_report_test.py
@@ -165,5 +165,5 @@ def test_hydrate_escalation_coverage_flags(mapped_search: CoverageGapReport) -> 
 def test_run_clean_exits_no_work(search: CoverageGapReport) -> None:
     resp_gen = []  # type: ignore
 
-    with patch.object(search._query, "run_iter", return_value=resp_gen):
+    with patch.object(search._query, "query_iter", return_value=resp_gen):
         search.run_reports()

--- a/tests/reports/coverage_gap_report_test.py
+++ b/tests/reports/coverage_gap_report_test.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from httpx import Response
 
 from pd_utils.model import ScheduleCoverage
 from pd_utils.model.escalation_rule_coverage import EscalationRuleCoverage
@@ -116,8 +115,7 @@ def mapped_search(search: CoverageGapReport) -> CoverageGapReport:
 
 
 def test_get_schedule_coverage(search: CoverageGapReport) -> None:
-    resps = [Response(200, content=SCHEDULE_RESP)]
-    with patch.object(search._http, "get", side_effect=resps):
+    with patch.object(search._query, "get", return_value=json.loads(SCHEDULE_RESP)):
 
         result = search.get_schedule_coverage("mock")
 
@@ -126,8 +124,7 @@ def test_get_schedule_coverage(search: CoverageGapReport) -> None:
 
 
 def test_get_schedule_coverage_fails(search: CoverageGapReport) -> None:
-    resps = [Response(401, content="Failure")]
-    with patch.object(search._http, "get", side_effect=resps):
+    with patch.object(search._query, "get", return_value=None):
 
         result = search.get_schedule_coverage("mock")
 

--- a/tests/reports/user_report_test.py
+++ b/tests/reports/user_report_test.py
@@ -112,7 +112,7 @@ def test_hydrate_on_schedule_flag(report: UserReport):
         "PSIUGWW": UserReportRow.build_from(json.loads(USER)),
         "PSIUGWX": UserReportRow.build_from(json.loads(USER)),
     }
-    mock_scheduled = {"PSIUGWW"}
+    mock_scheduled = {"PSIUGWW", "PSIUGXX"}
 
     report._hydrate_on_schedule_flag(mock_map, mock_scheduled)
 

--- a/tests/reports/user_report_test.py
+++ b/tests/reports/user_report_test.py
@@ -64,7 +64,7 @@ def test_get_users_and_teams(
     users: list[dict[str, Any]],
     expected_len: int,
 ) -> None:
-    with patch.object(report._query, "run_iter", return_value=users):
+    with patch.object(report._query, "query_iter", return_value=users):
         user_map, teams = report._get_users_and_teams()
 
     assert len(user_map) == expected_len
@@ -73,7 +73,7 @@ def test_get_users_and_teams(
 def test_get_team_memberships(report: UserReport):
     resp = [json.loads(MEMBERS)]
 
-    with patch.object(report._query, "run_iter", return_value=resp):
+    with patch.object(report._query, "query_iter", return_value=resp):
 
         result = report._get_team_memberships(EXPECTED_TEAMS)
     print(result)
@@ -101,7 +101,7 @@ def test_hydrate_team_membership(report: UserReport):
 def test_get_users_on_schedules(report: UserReport) -> None:
     resp = json.loads(SCHEDULES)["schedules"]
 
-    with patch.object(report._query, "run_iter", return_value=resp):
+    with patch.object(report._query, "query_iter", return_value=resp):
         result = report._get_users_on_schedules()
 
     assert result == EXPECTED_USERS

--- a/tests/tools/close_old_incidents_test.py
+++ b/tests/tools/close_old_incidents_test.py
@@ -56,7 +56,7 @@ def test_get_newest_log_entry(closer: CloseOldIncidents) -> None:
     mock_resp = json.loads(LOG_ENTRIES_RESP)["log_entries"][0]
     resp = [([mock_resp], None, None)]
 
-    with patch.object(closer._query, "run", side_effect=resp) as mockrun:
+    with patch.object(closer._query, "_query", side_effect=resp) as mockrun:
 
         results = closer._get_newest_log_entry("mock")
 
@@ -68,7 +68,7 @@ def test_get_all_incidents(closer: CloseOldIncidents) -> None:
     resps = json.loads(INCIDENTS_RESP)
     resp_gen = (r["incidents"][0] for r in resps)
 
-    with patch.object(closer._query, "run_iter", return_value=resp_gen):
+    with patch.object(closer._query, "query_iter", return_value=resp_gen):
 
         results = closer._get_all_incidents()
 
@@ -151,7 +151,7 @@ def test_close_incidents(
 
 def test_run_empty_results(closer: CloseOldIncidents) -> None:
     resp_gen = []  # type: ignore
-    with patch.object(closer._query, "run_iter", return_value=resp_gen) as http:
+    with patch.object(closer._query, "query_iter", return_value=resp_gen) as http:
         closer.run()
 
         assert http.call_count == 1
@@ -160,7 +160,7 @@ def test_run_empty_results(closer: CloseOldIncidents) -> None:
 def test_run_empty_ignore_activity(closer: CloseOldIncidents) -> None:
     resp_gen = []  # type: ignore
     closer._close_active = True
-    with patch.object(closer._query, "run_iter", return_value=resp_gen):
+    with patch.object(closer._query, "query_iter", return_value=resp_gen):
         with patch.object(closer, "_isolate_inactive_incidents") as avoid:
             closer.run()
 


### PR DESCRIPTION
- Do not consume deleted user ids from schedules
- Do not raise `KeyError` if inactive user exists on schedule during hydration
- General code cleaning, pull httpx operations into PagerDutyQuery class

resolves #22 
