### PR TITLE
Update typing generic to collections.abc

### DIFF
--- a/pd_utils/util/date_tool.py
+++ b/pd_utils/util/date_tool.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
-from typing import Sequence
 
 
 class DateTool:

--- a/pd_utils/util/io_util.py
+++ b/pd_utils/util/io_util.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import csv
 from io import StringIO
 from typing import Any
-from typing import Sequence
+from collections.abc import Sequence
 
 from pd_utils.model.base import Base
 

--- a/pd_utils/util/io_util.py
+++ b/pd_utils/util/io_util.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Sequence
 from io import StringIO
 from typing import Any
-from collections.abc import Sequence
 
 from pd_utils.model.base import Base
 

--- a/pd_utils/util/pagerduty_api.py
+++ b/pd_utils/util/pagerduty_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any
-from typing import Generator
+from collections.abc import Generator
 
 import httpx
 

--- a/pd_utils/util/pagerduty_api.py
+++ b/pd_utils/util/pagerduty_api.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 from collections.abc import Generator
+from typing import Any
 
 import httpx
 

--- a/pd_utils/util/runtime_init.py
+++ b/pd_utils/util/runtime_init.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import argparse
 import logging
-from typing import Sequence
+from collections.abc import Sequence
 
 from secretbox import SecretBox
 from secretbox.envfile_loader import EnvFileLoader


### PR DESCRIPTION
`typing.Sequence` and other generics are scheduled for deprecation as per https://peps.python.org/pep-0585/

`collections.abc.Sequence` should be used instead and is compatible with all versions of python currently supported.