### PR TITLE
Replace secretbox with runtime-yolk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.23.0,<1",
-    "secretbox>=2.6.3,<3"
+    "runtime-yolk>=1.0.0,<2"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.23.0,<1",
-    "runtime-yolk>=1.0.0,<2"
+    "runtime-yolk>=1.0.0,<2",
 ]
 
 [project.optional-dependencies]

--- a/src/pd_utils/cli/close_old_incidents_cli.py
+++ b/src/pd_utils/cli/close_old_incidents_cli.py
@@ -34,8 +34,8 @@ def main(args_in: list[str] | None = None) -> int:
     args = runtime.parse_args(args_in)
 
     client = CloseOldIncidents(
-        token=runtime.secrets.get("PAGERDUTY_TOKEN"),
-        email=runtime.secrets.get("PAGERDUTY_EMAIL"),
+        token=runtime.yolk.config.get("DEFAULT", "token"),
+        email=runtime.yolk.config.get("DEFAULT", "email"),
         close_after_days=int(args.close_after_days),
         close_active=args.close_active,
         close_priority=args.close_priority,

--- a/src/pd_utils/cli/close_old_incidents_cli.py
+++ b/src/pd_utils/cli/close_old_incidents_cli.py
@@ -8,7 +8,6 @@ from pd_utils.util import RuntimeInit
 def main(args_in: list[str] | None = None) -> int:
     """Run the script."""
     runtime = RuntimeInit("close-old-incidents")
-    runtime.init_secrets()
     runtime.add_standard_arguments()
     runtime.add_argument(
         "--inputfile",
@@ -30,7 +29,6 @@ def main(args_in: list[str] | None = None) -> int:
         action="store_true",
         help="When present, consider incidents with priority for closing",
     )
-    runtime.init_logging()
     args = runtime.parse_args(args_in)
 
     client = CloseOldIncidents(

--- a/src/pd_utils/cli/coverage_gap_report_cli.py
+++ b/src/pd_utils/cli/coverage_gap_report_cli.py
@@ -12,8 +12,6 @@ from pd_utils.util import RuntimeInit
 def main(*, _args: list[str] | None = None) -> int:
     """CLI entry."""
     runtime = RuntimeInit("coverage-gap-report")
-    runtime.init_secrets()
-    runtime.init_logging()
     runtime.add_standard_arguments(email=False)
     runtime.add_argument(
         flag="--look-ahead",

--- a/src/pd_utils/cli/user_report_cli.py
+++ b/src/pd_utils/cli/user_report_cli.py
@@ -12,7 +12,6 @@ from pd_utils.util import RuntimeInit
 def main(_args: list[str] | None = None) -> int:
     """Main point of entry for CLI."""
     runtime = RuntimeInit("user-report")
-    runtime.init_secrets()
     runtime.add_standard_arguments(email=False)
     runtime.add_argument(
         flag="--team_ids",
@@ -21,7 +20,6 @@ def main(_args: list[str] | None = None) -> int:
         nargs="*",
     )
     args = runtime.parse_args(_args)
-    runtime.init_logging()
 
     print("Starting User Report, this pull can take some time.")
     report = UserReport(args.token).run_report(team_ids=args.team_ids)

--- a/src/pd_utils/util/runtime_init.py
+++ b/src/pd_utils/util/runtime_init.py
@@ -3,45 +3,28 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 from collections.abc import Sequence
 
 from runtime_yolk import Yolk
 
 
 class RuntimeInit:
-    def __init__(self, prog_name: str) -> None:
+    def __init__(self, prog_name: str, *, _config_name: str = "pd-util") -> None:
         """Setup runtime environment for all scripts."""
         self.yolk = Yolk()
+        self.yolk.load_env()
+        self.yolk.load_config(_config_name)
+        self.yolk.set_logging()
+
         self.parser = argparse.ArgumentParser(
             prog=prog_name,
             description="Pagerduty command line utilities.",
             epilog="See: https://github.com/Preocts/pagerduty-utils",
         )
 
-    def init_secrets(self, env_file: str | None = None) -> None:
-        """
-        Initialize secrets from a file and environment.
-
-        Args:
-            env_file: The path to the file containing the secrets.
-        """
-        self.yolk.load_env(env_file or ".env")
-
-    def init_logging(self) -> None:
-        """Init logging level and format."""
-        level = os.getenv(
-            "LOGGING_LEVEL",
-            self.yolk.config.get(
-                "DEFAULT",
-                "logging_level",
-            ),
-        )
-        logging.getLogger().setLevel(level)
-        logging.basicConfig(
-            level=level,
-            format="%(asctime)s - %(levelname)s - %(module)s - %(message)s",
-        )
+    def get_logger(self) -> logging.Logger:
+        """Get the root logger."""
+        return self.yolk.get_logger()
 
     def add_argument(
         self,

--- a/tests/cli/close_old_incidents_cli_test.py
+++ b/tests/cli/close_old_incidents_cli_test.py
@@ -10,7 +10,6 @@ def test_main_no_optional_args() -> None:
     with patch.object(close_old_incidents_cli, "CloseOldIncidents") as mockclass:
         close_old_incidents_cli.main(["--token", "mock", "--email", "mock@mock.com"])
         kwargs = mockclass.call_args.kwargs
-        print(mockclass.call_args.kwargs)
 
     assert kwargs == {
         "token": "mock",

--- a/tests/fixture/mock-pd-util.ini
+++ b/tests/fixture/mock-pd-util.ini
@@ -1,0 +1,4 @@
+[DEFAULT]
+logging_level={{LOGGING_LEVEL}}
+token={{PAGERDUTY_TOKEN}}
+email={{PAGERDUTY_EMAIL}}


### PR DESCRIPTION
- [x] Tests failing pending change and release for `runtime-yolk`. Its behavior currently defaults to DEBUG logging. It should reflect the standard logging behavior and default to ERROR level.
- [x] Adjust runtimes (cli) to handle loading config, if exists
- [ ] Add timeout to config

resolves #39 
resolves #38 
