### PR TITLE
Add timeout control for modules

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -23,6 +23,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
 
     steps:
       - name: "Repo checkout"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,6 @@ repos:
       - id: check-docstring-first
       - id: debug-statements
 
-  # Keep setup.cfg clean
-  - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.1.0
-    hooks:
-      - id: setup-cfg-fmt
-
   # Adds a standard feel to import segments, adds future annotations
   - repo: https://github.com/asottile/reorder_python_imports
     rev: v3.8.5
@@ -42,7 +36,7 @@ repos:
     rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black>=21.12b0]
+        additional_dependencies: [black>=22.10.0]
 
   # Flake8 for linting, line-length adjusted to match Black default
   - repo: https://github.com/PyCQA/flake8

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ instance. These will be called out and can be provided with the `--email` flag,
 in an `.env` file under `PAGERDUTY_EMAIL`, or in the environ under the same
 name.
 
-All scripts accept the `--logging-level` flag which defaults to `INFO`.
+All scripts accept the `--logging-level` flag which defaults to `ERROR`.
 
 All scripts can be run from the installed shell scripts or by invoking directly
 with `python -m pd_utils.script_name`
@@ -114,7 +114,7 @@ optional arguments:
   -h, --help            show this help message and exit
   --token TOKEN         PagerDuty API Token (default: $PAGERDUTY_TOKEN)
   --logging-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
-                        Logging level (default: $LOGGING_LEVEL | INFO)
+                        Logging level (default: $LOGGING_LEVEL | ERROR)
   --team_ids [TEAM_IDS [TEAM_IDS ...]]
                         List of team ids to include in report.
 
@@ -148,7 +148,7 @@ optional arguments:
   -h, --help            show this help message and exit
   --token TOKEN         PagerDuty API Token (default: $PAGERDUTY_TOKEN)
   --logging-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
-                        Logging level (default: $LOGGING_LEVEL | INFO)
+                        Logging level (default: $LOGGING_LEVEL | ERROR)
   --look-ahead LOOK_AHEAD
                         Number of days to look ahead for gaps, default 14
 
@@ -216,7 +216,7 @@ optional arguments:
   --token TOKEN         PagerDuty API Token (default: $PAGERDUTY_TOKEN)
   --email EMAIL         PagerDuty Email (default: $PAGERDUTY_EMAIL)
   --logging-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
-                        Logging level (default: $LOGGING_LEVEL | INFO)
+                        Logging level (default: $LOGGING_LEVEL | ERROR)
   --inputfile INPUTFILE
                         Provide a csv file to work from. If not provided a new file will be created.
   --close-after-days CLOSE_AFTER_DAYS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ max-line-length = 88
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py38,py39,py310,py311,coverage,pre-commit
+envlist = py38,py39,py310,py311,py312,coverage,pre-commit
 skip_missing_interpreters = true
 isolated_build = True
 
@@ -117,7 +117,7 @@ commands =
     coverage run -p -m pytest tests/
 
 [testenv:coverage]
-depends = py38,py39,py310,py311
+depends = py38,py39,py310,py311,py312
 parallel_show_output = true
 commands =
     python -m coverage combine

--- a/src/pd_utils/cli/close_old_incidents_cli.py
+++ b/src/pd_utils/cli/close_old_incidents_cli.py
@@ -33,9 +33,13 @@ def main(args_in: list[str] | None = None) -> int:
     runtime.init_logging()
     args = runtime.parse_args(args_in)
 
-    client = CloseOldIncidents(
+    pdconn = runtime.get_pagerduty_connection(
         token=runtime.secrets.get("PAGERDUTY_TOKEN"),
         email=runtime.secrets.get("PAGERDUTY_EMAIL"),
+    )
+
+    client = CloseOldIncidents(
+        pagerduty_connection=pdconn,
         close_after_days=int(args.close_after_days),
         close_active=args.close_active,
         close_priority=args.close_priority,

--- a/src/pd_utils/cli/coverage_gap_report_cli.py
+++ b/src/pd_utils/cli/coverage_gap_report_cli.py
@@ -21,7 +21,15 @@ def main(*, _args: list[str] | None = None) -> int:
         help_="Number of days to look ahead for gaps, default 14",
     )
     args = runtime.parse_args(_args)
-    client = CoverageGapReport(token=args.token, look_ahead_days=int(args.look_ahead))
+
+    pdconn = runtime.get_pagerduty_connection(
+        token=runtime.secrets.get("PAGERDUTY_TOKEN"),
+    )
+
+    client = CoverageGapReport(
+        pagerduty_connection=pdconn,
+        look_ahead_days=int(args.look_ahead),
+    )
     schedule_report, escalation_report = client.run_reports()
 
     now = datetool.utcnow_isotime().split("T")[0]

--- a/src/pd_utils/cli/user_report_cli.py
+++ b/src/pd_utils/cli/user_report_cli.py
@@ -23,8 +23,12 @@ def main(_args: list[str] | None = None) -> int:
     args = runtime.parse_args(_args)
     runtime.init_logging()
 
+    pdconn = runtime.get_pagerduty_connection(
+        token=runtime.secrets.get("PAGERDUTY_TOKEN"),
+    )
+
     print("Starting User Report, this pull can take some time.")
-    report = UserReport(args.token).run_report(team_ids=args.team_ids)
+    report = UserReport(pdconn).run_report(team_ids=args.team_ids)
 
     now = datetool.utcnow_isotime().split("T")[0]
     ioutil.write_to_file(f"user_report{now}.csv", report)

--- a/src/pd_utils/report/coverage_gap_report.py
+++ b/src/pd_utils/report/coverage_gap_report.py
@@ -21,15 +21,14 @@ class CoverageGapReport:
 
     def __init__(
         self,
-        token: str,
+        pagerduty_connection: PagerDutyAPI,
         *,
         max_query_limit: int = 100,
         look_ahead_days: int = 14,
     ) -> None:
         """
-        Required: PagerDuty API v2 token with read access.
-
         Args:
+            pagerduty_connection: PagerDutyAPI object
             max_query_limit: Number of objects to request at once from PD (max: 100)
             look_ahead_days: Number of days to look ahead on schedule (default: 14)
         """
@@ -39,7 +38,7 @@ class CoverageGapReport:
         self._schedule_map: dict[str, SchCoverage] = {}
         self._escalation_map: dict[str, EscCoverage] = {}
 
-        self._query = PagerDutyAPI(token)
+        self._query = pagerduty_connection
 
     def run_reports(self) -> tuple[str, str]:
         """

--- a/src/pd_utils/report/user_report.py
+++ b/src/pd_utils/report/user_report.py
@@ -23,14 +23,18 @@ class UserReport:
 
     log = logging.getLogger()
 
-    def __init__(self, token: str, *, max_query_limit: int = 100) -> None:
+    def __init__(
+        self,
+        pagerduty_connection: PagerDutyAPI,
+        *,
+        max_query_limit: int = 100,
+    ) -> None:
         """
-        Required: PagerDuty API v2 token with read access.
-
         Args:
+            pagerduty_connection: PagerDutyAPI object to use
             max_query_limit: Number of objects to request at once from PD (max: 100)
         """
-        self._query = PagerDutyAPI(token)
+        self._query = pagerduty_connection
         self._max_query_limit = max_query_limit
 
     def run_report(self, team_ids: list[str] | None = None) -> str:

--- a/src/pd_utils/tool/close_old_incidents.py
+++ b/src/pd_utils/tool/close_old_incidents.py
@@ -33,8 +33,7 @@ class CloseOldIncidents:
 
     def __init__(
         self,
-        token: str,
-        email: str,
+        pagerduty_connection: PagerDutyAPI,
         *,
         close_after_days: int = 10,
         close_active: bool = False,
@@ -44,14 +43,13 @@ class CloseOldIncidents:
         Used to clean up and close old incidents in PagerDuty.
 
         Args:
-            token: API v2 read/write token for PagerDuty
-            email: Valid PagerDuty account email with permissions for closing incidents
+            pagerduty_connection: PagerDutyAPI object to use
             close_after_days: Incidents older than this are considered for closing
             close_after: When true, old incidents are closed regardless of activity
             close_priority: When true, consider incidents with priority for closing
         """
 
-        self._pdapi = PagerDutyAPI(token, email)
+        self._pdapi = pagerduty_connection
         self._max_query_limit = 100
         self._close_after_seconds = close_after_days * 86_400
         self._close_active = close_active

--- a/src/pd_utils/util/pagerduty_api.py
+++ b/src/pd_utils/util/pagerduty_api.py
@@ -17,15 +17,21 @@ class PagerDutyAPI:
     class QueryError(Exception):
         ...
 
-    def __init__(self, token: str, email: str | None = None) -> None:
-        """Initilize httpx client for queries to list endpoints."""
+    def __init__(
+        self,
+        token: str,
+        email: str | None = None,
+        timeout_seconds: int | None = None,
+    ) -> None:
+        """Initilize httpx client for queries to list endpoints. Timeout default 60s."""
+        timeout = timeout_seconds if timeout_seconds is not None else 60
         headers = {
             "Accept": "application/vnd.pagerduty+json;version=2",
             "Authorization": f"Token token={token}",
         }
         headers.update({"From": email} if email else {})
 
-        self._http = httpx.Client(headers=headers)
+        self._http = httpx.Client(headers=headers, timeout=timeout)
         self._params: dict[str, Any] = {}
         self._route: str | None = None
         self._object_name: str | None = None

--- a/src/pd_utils/util/runtime_init.py
+++ b/src/pd_utils/util/runtime_init.py
@@ -29,8 +29,8 @@ class RuntimeInit:
         self.secrets.use_loaders(EnvFileLoader(env_file))
 
     def init_logging(self) -> None:
-        """Init logging level and format. (default: $LOGGING_LEVEL | INFO)"""
-        level = self.secrets.get("LOGGING_LEVEL", "INFO")
+        """Init logging level and format. (default: $LOGGING_LEVEL | ERROR)"""
+        level = self.secrets.get("LOGGING_LEVEL", "ERROR")
         logging.getLogger().setLevel(level)
         logging.basicConfig(
             level=level,
@@ -93,9 +93,9 @@ class RuntimeInit:
         if loglevel:
             self.parser.add_argument(
                 "--logging-level",
-                help="Logging level (default: $LOGGING_LEVEL | INFO)",
+                help="Logging level (default: $LOGGING_LEVEL | ERROR)",
                 choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-                default=self.secrets.get("LOGGING_LEVEL", "INFO"),
+                default=self.secrets.get("LOGGING_LEVEL", "ERROR"),
             )
 
     def parse_args(self, args: Sequence[str] | None = None) -> argparse.Namespace:

--- a/src/pd_utils/util/runtime_init.py
+++ b/src/pd_utils/util/runtime_init.py
@@ -5,6 +5,7 @@ import argparse
 import logging
 from collections.abc import Sequence
 
+from pd_utils.util.pagerduty_api import PagerDutyAPI
 from secretbox import SecretBox
 from secretbox.envfile_loader import EnvFileLoader
 
@@ -118,5 +119,20 @@ class RuntimeInit:
             self.secrets.set("PAGERDUTY_EMAIL", parsed.email)
         if "logging_level" in parsed:
             self.secrets.set("LOGGING_LEVEL", parsed.logging_level)
+        if "timeout" in parsed:
+            self.secrets.set("PAGERDUTY_TIMEOUT", str(parsed.timeout))
 
         return parsed
+
+    def get_pagerduty_connection(
+        self,
+        token: str | None = None,
+        email: str | None = None,
+        timeout: int | None = None,
+    ) -> PagerDutyAPI:
+        _timeout = self.secrets.get("PAGERDUTY_TIMEOUT", "None")
+        return PagerDutyAPI(
+            token=token or self.secrets.get("PAGERDUTY_TOKEN", ""),
+            email=email or self.secrets.get("PAGERDUTY_EMAIL", "") or None,
+            timeout_seconds=timeout or int(_timeout) if _timeout != "None" else None,
+        )

--- a/src/pd_utils/util/runtime_init.py
+++ b/src/pd_utils/util/runtime_init.py
@@ -69,6 +69,7 @@ class RuntimeInit:
         token: bool = True,
         email: bool = True,
         loglevel: bool = True,
+        timeout: bool = True,
     ) -> None:
         """
         Add most common command line arguments to the parser.
@@ -77,6 +78,7 @@ class RuntimeInit:
             token: When true collects optional API token
             email: When true collects optional PagerDuty account email
             loglevel: When true collects optional logging level
+            timeout: Timeout seconds for HTTP calls
         """
         if token:
             self.parser.add_argument(
@@ -96,6 +98,12 @@ class RuntimeInit:
                 help="Logging level (default: $LOGGING_LEVEL | ERROR)",
                 choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
                 default=self.secrets.get("LOGGING_LEVEL", "ERROR"),
+            )
+        if timeout:
+            self.parser.add_argument(
+                "--timeout",
+                help="Timeout seconds for HTTP calls (default: 60)",
+                default=60,
             )
 
     def parse_args(self, args: Sequence[str] | None = None) -> argparse.Namespace:

--- a/tests/cli/close_old_incidents_cli_test.py
+++ b/tests/cli/close_old_incidents_cli_test.py
@@ -10,15 +10,10 @@ def test_main_no_optional_args() -> None:
     with patch.object(close_old_incidents_cli, "CloseOldIncidents") as mockclass:
         close_old_incidents_cli.main(["--token", "mock", "--email", "mock@mock.com"])
         kwargs = mockclass.call_args.kwargs
-        print(mockclass.call_args.kwargs)
 
-    assert kwargs == {
-        "token": "mock",
-        "email": "mock@mock.com",
-        "close_after_days": 10,
-        "close_active": False,
-        "close_priority": False,
-    }
+    assert kwargs["close_after_days"] == 10
+    assert kwargs["close_active"] is False
+    assert kwargs["close_priority"] is False
 
 
 def test_main_optional_args() -> None:
@@ -37,10 +32,6 @@ def test_main_optional_args() -> None:
         )
         kwargs = mockclass.call_args.kwargs
 
-    assert kwargs == {
-        "token": "mock",
-        "email": "mock@mock.com",
-        "close_after_days": 5,
-        "close_active": True,
-        "close_priority": True,
-    }
+    assert kwargs["close_after_days"] == 5
+    assert kwargs["close_active"] is True
+    assert kwargs["close_priority"] is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,21 @@ from __future__ import annotations
 import os
 import tempfile
 from collections.abc import Generator
+from unittest.mock import patch
 
 import pytest
+
+MOCK_ENV = {
+    "PAGERDUTY_TOKEN": "mock",
+    "PAGERDUTY_EMAIL": "mock",
+    "PAGERDUTY_TIMEOUT": "42",
+}
+
+
+@pytest.fixture(autouse=True)
+def mock_environment_variables() -> Generator[None, None, None]:
+    with patch.dict(os.environ, MOCK_ENV):
+        yield None
 
 
 @pytest.fixture

--- a/tests/reports/coverage_gap_report_test.py
+++ b/tests/reports/coverage_gap_report_test.py
@@ -8,6 +8,7 @@ import pytest
 from pd_utils.model import ScheduleCoverage
 from pd_utils.model.escalation_rule_coverage import EscalationRuleCoverage
 from pd_utils.report.coverage_gap_report import CoverageGapReport
+from pd_utils.util.pagerduty_api import PagerDutyAPI
 
 SCHEDULES_RESP = Path("tests/fixture/cov_gap/schedule_list.json").read_text()
 EXPECTED_IDS = {"PG3MDI8", "P4TPEME"}
@@ -21,7 +22,8 @@ EP_EXPECTED_COUNT = 2
 
 @pytest.fixture
 def search() -> CoverageGapReport:
-    return CoverageGapReport("mock", max_query_limit=1, look_ahead_days=14)
+    pdconn = PagerDutyAPI("", "", 1)
+    return CoverageGapReport(pdconn, max_query_limit=1, look_ahead_days=14)
 
 
 @pytest.fixture

--- a/tests/reports/user_report_test.py
+++ b/tests/reports/user_report_test.py
@@ -10,6 +10,7 @@ from pd_utils.model import UserReportRow
 from pd_utils.model import UserTeam
 from pd_utils.report.user_report import _Team
 from pd_utils.report.user_report import UserReport
+from pd_utils.util.pagerduty_api import PagerDutyAPI
 
 USER = Path("tests/fixture/user_report/user.json").read_text()
 MEMBERS = Path("tests/fixture/user_report/members.json").read_text()
@@ -23,7 +24,7 @@ EXPECTED_USERS = {"PSIUGWW", "PSIUGWX"}
 
 @pytest.fixture
 def report() -> UserReport:
-    return UserReport("mock")
+    return UserReport(PagerDutyAPI("", "", 1))
 
 
 def test_run_report(report: UserReport) -> None:

--- a/tests/tools/close_old_incidents_test.py
+++ b/tests/tools/close_old_incidents_test.py
@@ -10,6 +10,7 @@ from pd_utils.model import Incident
 from pd_utils.tool import close_old_incidents
 from pd_utils.tool.close_old_incidents import CloseOldIncidents
 from pd_utils.util import datetool
+from pd_utils.util.pagerduty_api import PagerDutyAPI
 
 INCIDENTS_RESP = Path("tests/fixture/close-incidents/incidents.json").read_text()
 EXPECTED_IDS = {"Q36LM3UBN4V94O", "Q3YH44AL350A23"}
@@ -31,7 +32,7 @@ MOCK_REPORT = "\n".join(
 
 @pytest.fixture
 def closer() -> CloseOldIncidents:
-    return CloseOldIncidents("mock", "mock")
+    return CloseOldIncidents(PagerDutyAPI("", "", 1))
 
 
 @pytest.fixture

--- a/tests/util/runtime_init_test.py
+++ b/tests/util/runtime_init_test.py
@@ -60,16 +60,6 @@ def test_init_logging(runtime: RuntimeInit, caplog: LogCaptureFixture) -> None:
     assert "critical" in caplog.text
 
 
-def test_empty_parse_arg_results(runtime: RuntimeInit) -> None:
-    runtime.add_standard_arguments()
-
-    args = runtime.parse_args([])
-
-    assert args.token == ""
-    assert args.email == ""
-    assert args.logging_level == "INFO"
-
-
 def test_environ_parse_arg_defaults(runtime: RuntimeInit) -> None:
     runtime.secrets.set("PAGERDUTY_TOKEN", "TOKEN")
     runtime.secrets.set("PAGERDUTY_EMAIL", "EMAIL")

--- a/tests/util/runtime_init_test.py
+++ b/tests/util/runtime_init_test.py
@@ -27,19 +27,26 @@ def test_add_standard_arguments(runtime: RuntimeInit) -> None:
 
     args = runtime.parse_args([])
 
-    assert "token" in args
-    assert "email" in args
-    assert "logging_level" in args
+    assert "token" in args and args.token == ""
+    assert "email" in args and args.email == ""
+    assert "logging_level" in args and args.logging_level == "ERROR"
+    assert "timeout" in args and args.timeout == 60
 
 
 def test_add_standard_arguments_toggled_off(runtime: RuntimeInit) -> None:
-    runtime.add_standard_arguments(token=False, email=False, loglevel=False)
+    runtime.add_standard_arguments(
+        token=False,
+        email=False,
+        loglevel=False,
+        timeout=False,
+    )
 
     args = runtime.parse_args([])
 
     assert "token" not in args
     assert "email" not in args
     assert "logging_level" not in args
+    assert "timeout" not in args
 
 
 def test_init_logging(runtime: RuntimeInit, caplog: LogCaptureFixture) -> None:


### PR DESCRIPTION
- Added `timeout` cli option for controlling the default HTTP timeout and increased the default to 60 seconds.
- Clean up the CI and projects files. 
- Refactor the `PagerDutyAPI` object out of the individual reports and tools. The object is now created by `RuntimeInit` and provided as an injected dependency. 
- Bumped default logging to `ERROR` instead of `INFO`. 

closes #38 